### PR TITLE
Fix workflow: remove --assignee from gh issue/pr create

### DIFF
--- a/.github/workflows/helio-upstream-sync.yml
+++ b/.github/workflows/helio-upstream-sync.yml
@@ -212,7 +212,6 @@ jobs:
           gh issue create \
             --title "Upstream sync failed: $LATEST (merge conflicts)" \
             --label "upstream-sync" \
-            --assignee "HelioPri" \
             --body "$(cat <<ISSUE_EOF
           ## Merge conflicts detected syncing $LATEST
 
@@ -279,7 +278,6 @@ jobs:
             --base "$TARGET" \
             --head "$BRANCH" \
             --title "Upstream sync: $LATEST" \
-            --assignee "HelioPri" \
             --body "$(cat <<PR_EOF
           ## Upstream Sync: $LATEST
 
@@ -328,7 +326,6 @@ jobs:
           gh issue create \
             --title "Upstream sync build failed: $LATEST" \
             --label "upstream-sync" \
-            --assignee "HelioPri" \
             --body "$(cat <<ISSUE_EOF
           ## Build failed after merging $LATEST
 

--- a/.github/workflows/helio-upstream-watch.yml
+++ b/.github/workflows/helio-upstream-watch.yml
@@ -175,7 +175,6 @@ jobs:
             ISSUE_URL=$(gh issue create \
               --title "Upstream Activity Watch" \
               --label "upstream-watch" \
-              --assignee "HelioPri" \
               --body "This issue tracks upstream OrcaSlicer activity relevant to the Helio integration. Updated weekly by the helio-upstream-watch workflow.")
             ISSUE_NUMBER=$(echo "$ISSUE_URL" | grep -o '[0-9]*$')
             echo "Created new watch issue #$ISSUE_NUMBER"


### PR DESCRIPTION
## Summary
- Remove `--assignee "HelioPri"` from all `gh issue create` and `gh pr create` calls
- `GITHUB_TOKEN` bot doesn't have permission to assign users, causing workflow failures
- Self-assign from GitHub UI instead

Fixes the watch workflow failure: `could not assign user: 'HelioPri' not found`