### PR TITLE
Fix Helio button visibility and improve startup defaults

### DIFF
--- a/src/libslic3r/AppConfig.cpp
+++ b/src/libslic3r/AppConfig.cpp
@@ -450,7 +450,7 @@ void AppConfig::set_defaults()
         if (!get("helio_enable").empty()) {
             set_bool("enable_helio_processing", get_bool("helio_enable"));
         } else {
-            set_bool("enable_helio_processing", true);
+            set_bool("enable_helio_processing", false);
         }
     }
     if (get("helio_api_china").empty()) {

--- a/src/slic3r/GUI/GCodeViewer.hpp
+++ b/src/slic3r/GUI/GCodeViewer.hpp
@@ -320,6 +320,13 @@ public:
 
     void set_view_type(libvgcode::EViewType type) {
         m_viewer.set_view_type(type);
+        // Sync dropdown selection index with the new view type
+        for (int i = 0; i < static_cast<int>(view_type_items.size()); ++i) {
+            if (view_type_items[i] == type) {
+                m_view_type_sel = i;
+                break;
+            }
+        }
     }
     void reset_visible(libvgcode::EViewType type) {
         if (type == libvgcode::EViewType::FeatureType) {

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -7419,10 +7419,8 @@ void GUI_App::request_helio_supported_data()
     std::string helio_api_url = Slic3r::HelioQuery::get_helio_api_url();
     std::string helio_api_key = Slic3r::HelioQuery::get_helio_pat();
 
-    if (!HelioQuery::global_printers_fully_loaded || !HelioQuery::global_materials_fully_loaded) {
-        Slic3r::HelioQuery::request_all_support_machine(helio_api_url, helio_api_key);
-        Slic3r::HelioQuery::request_all_support_materials(helio_api_url, helio_api_key);
-    }
+    Slic3r::HelioQuery::request_all_support_machine(helio_api_url, helio_api_key);
+    Slic3r::HelioQuery::request_all_support_materials(helio_api_url, helio_api_key);
 }
 
 void GUI_App::remove_mall_system_dialog()

--- a/src/slic3r/GUI/HelioReleaseNote.cpp
+++ b/src/slic3r/GUI/HelioReleaseNote.cpp
@@ -181,7 +181,11 @@ void HelioStatementDialog::on_confirm(wxMouseEvent& e)
     show_pat_page();
     request_pat();
 
-    // Helio button visibility is handled via the slice dropdown in OrcaSlicer
+    // Show the Helio button in main window immediately (mirrors on_uninstall hide logic)
+    if (wxGetApp().mainframe->expand_program_holder) {
+        wxGetApp().mainframe->expand_program_holder->ShowExpandButton(wxGetApp().mainframe->expand_helio_id, true);
+        wxGetApp().mainframe->Layout();
+    }
 
     Layout();
     Fit();

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -10338,6 +10338,15 @@ private:
             HelioQuery::request_all_support_materials(helio_api_url, helio_api_key);
             HelioQuery::request_all_support_machine(helio_api_url, helio_api_key);
 
+            // Wait for async HTTP requests to complete (Http::perform() is async)
+            constexpr int timeout_ms = 60000;
+            int elapsed = 0;
+            while (elapsed < timeout_ms &&
+                   (!HelioQuery::global_materials_fully_loaded || !HelioQuery::global_printers_fully_loaded)) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(100));
+                elapsed += 100;
+            }
+
             // Post result back to GUI thread
             wxTheApp->CallAfter([this]() {
                 on_refresh_complete();

--- a/src/slic3r/GUI/Preferences.cpp
+++ b/src/slic3r/GUI/Preferences.cpp
@@ -942,6 +942,20 @@ wxBoxSizer *PreferencesDialog::create_item_checkbox(wxString title, wxString too
         //     wxGetApp().switch_staff_pick(pbool);
         // }
 
+        if (param == "enable_helio_processing") {
+            bool enabled = checkbox->GetValue();
+            if (enabled) {
+                wxGetApp().CallAfter([] { wxGetApp().request_helio_supported_data(); });
+            }
+            // Show/hide the Helio button immediately
+            if (wxGetApp().mainframe && wxGetApp().mainframe->expand_program_holder) {
+                wxGetApp().mainframe->expand_program_holder->ShowExpandButton(
+                    wxGetApp().mainframe->expand_helio_id, enabled);
+                wxGetApp().mainframe->Layout();
+            }
+            BOOST_LOG_TRIVIAL(info) << "enable_helio_processing toggled: " << (enabled ? "true" : "false");
+        }
+
         if (param == "sync_user_preset") {
             bool sync = app_config->get("sync_user_preset") == "true" ? true : false;
             if (sync) {


### PR DESCRIPTION
## Summary
- Default `enable_helio_processing` to `false` for new installs
- Fix Helio button not appearing on first-time install or re-install after uninstall (now calls `ShowExpandButton` immediately, matching the existing uninstall hide logic)
- Preferences toggle now shows/hides the Helio button without requiring restart
- Sync GCodeViewer dropdown selection when view type changes programmatically
- Always request Helio data on startup (remove stale "already loaded" guard)
- Add 60s timeout for async HTTP requests in Plater refresh

## Test plan
- [ ] Fresh install: verify Helio button hidden by default
- [ ] Enable via ExpandCenterDialog: verify button appears immediately
- [ ] Uninstall via dialog: verify button disappears
- [ ] Re-install: verify button reappears without restart
- [ ] Toggle in Preferences: verify button shows/hides immediately
- [ ] Verify GCodeViewer dropdown stays in sync after programmatic view type change

🤖 Generated with [Claude Code](https://claude.com/claude-code)