### PR TITLE
Add Helio release workflow

### DIFF
--- a/.github/workflows/build_orca.yml
+++ b/.github/workflows/build_orca.yml
@@ -163,7 +163,7 @@ jobs:
 
  # Thanks to RaySajuuk, it's working now
       - name: Sign app and notary
-        if: ((github.repository == 'OrcaSlicer/OrcaSlicer' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/'))) || (vars.ENABLE_SIGNING == 'true' && github.event_name != 'pull_request')) && runner.os == 'macOS' && inputs.macos-combine-only
+        if: ((github.repository == 'OrcaSlicer/OrcaSlicer' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/'))) || (vars.ENABLE_SIGNING == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.merged == true))) && runner.os == 'macOS' && inputs.macos-combine-only
         working-directory: ${{ github.workspace }}
         env:
           BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
@@ -217,7 +217,7 @@ jobs:
           fi
 
       - name: Create DMG without notary
-        if: ${{ !((github.repository == 'OrcaSlicer/OrcaSlicer' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/'))) || (vars.ENABLE_SIGNING == 'true' && github.event_name != 'pull_request')) && runner.os == 'macOS' && inputs.macos-combine-only }}
+        if: ${{ !((github.repository == 'OrcaSlicer/OrcaSlicer' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/'))) || (vars.ENABLE_SIGNING == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.merged == true))) && runner.os == 'macOS' && inputs.macos-combine-only }}
         working-directory: ${{ github.workspace }}
         run: |
           mkdir -p ${{ github.workspace }}/build/universal/OrcaSlicer_dmg

--- a/.github/workflows/build_orca.yml
+++ b/.github/workflows/build_orca.yml
@@ -163,7 +163,7 @@ jobs:
 
  # Thanks to RaySajuuk, it's working now
       - name: Sign app and notary
-        if: (github.repository == 'OrcaSlicer/OrcaSlicer' || vars.ENABLE_SIGNING == 'true') && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') || vars.ENABLE_SIGNING == 'true') && runner.os == 'macOS' && inputs.macos-combine-only
+        if: (github.repository == 'OrcaSlicer/OrcaSlicer' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) || (vars.ENABLE_SIGNING == 'true' && github.event_name != 'pull_request')) && runner.os == 'macOS' && inputs.macos-combine-only
         working-directory: ${{ github.workspace }}
         env:
           BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
@@ -217,7 +217,7 @@ jobs:
           fi
 
       - name: Create DMG without notary
-        if: github.ref != 'refs/heads/main' && vars.ENABLE_SIGNING != 'true' && runner.os == 'macOS' && inputs.macos-combine-only
+        if: github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/heads/release/') && vars.ENABLE_SIGNING != 'true' && runner.os == 'macOS' && inputs.macos-combine-only
         working-directory: ${{ github.workspace }}
         run: |
           mkdir -p ${{ github.workspace }}/build/universal/OrcaSlicer_dmg

--- a/.github/workflows/build_orca.yml
+++ b/.github/workflows/build_orca.yml
@@ -217,7 +217,7 @@ jobs:
           fi
 
       - name: Create DMG without notary
-        if: !((github.repository == 'OrcaSlicer/OrcaSlicer' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/'))) || (vars.ENABLE_SIGNING == 'true' && github.event_name != 'pull_request')) && runner.os == 'macOS' && inputs.macos-combine-only
+        if: ${{ !((github.repository == 'OrcaSlicer/OrcaSlicer' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/'))) || (vars.ENABLE_SIGNING == 'true' && github.event_name != 'pull_request')) && runner.os == 'macOS' && inputs.macos-combine-only }}
         working-directory: ${{ github.workspace }}
         run: |
           mkdir -p ${{ github.workspace }}/build/universal/OrcaSlicer_dmg

--- a/.github/workflows/build_orca.yml
+++ b/.github/workflows/build_orca.yml
@@ -217,7 +217,7 @@ jobs:
           fi
 
       - name: Create DMG without notary
-        if: github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/heads/release/') && vars.ENABLE_SIGNING != 'true' && runner.os == 'macOS' && inputs.macos-combine-only
+        if: github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/heads/release/') && (vars.ENABLE_SIGNING != 'true' || github.event_name == 'pull_request') && runner.os == 'macOS' && inputs.macos-combine-only
         working-directory: ${{ github.workspace }}
         run: |
           mkdir -p ${{ github.workspace }}/build/universal/OrcaSlicer_dmg

--- a/.github/workflows/build_orca.yml
+++ b/.github/workflows/build_orca.yml
@@ -163,7 +163,7 @@ jobs:
 
  # Thanks to RaySajuuk, it's working now
       - name: Sign app and notary
-        if: (github.repository == 'OrcaSlicer/OrcaSlicer' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) || (vars.ENABLE_SIGNING == 'true' && github.event_name != 'pull_request')) && runner.os == 'macOS' && inputs.macos-combine-only
+        if: ((github.repository == 'OrcaSlicer/OrcaSlicer' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/'))) || (vars.ENABLE_SIGNING == 'true' && github.event_name != 'pull_request')) && runner.os == 'macOS' && inputs.macos-combine-only
         working-directory: ${{ github.workspace }}
         env:
           BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
@@ -217,7 +217,7 @@ jobs:
           fi
 
       - name: Create DMG without notary
-        if: github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/heads/release/') && (vars.ENABLE_SIGNING != 'true' || github.event_name == 'pull_request') && runner.os == 'macOS' && inputs.macos-combine-only
+        if: !((github.repository == 'OrcaSlicer/OrcaSlicer' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/'))) || (vars.ENABLE_SIGNING == 'true' && github.event_name != 'pull_request')) && runner.os == 'macOS' && inputs.macos-combine-only
         working-directory: ${{ github.workspace }}
         run: |
           mkdir -p ${{ github.workspace }}/build/universal/OrcaSlicer_dmg

--- a/.github/workflows/build_orca.yml
+++ b/.github/workflows/build_orca.yml
@@ -163,7 +163,7 @@ jobs:
 
  # Thanks to RaySajuuk, it's working now
       - name: Sign app and notary
-        if: github.repository == 'OrcaSlicer/OrcaSlicer' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) && runner.os == 'macOS' && inputs.macos-combine-only
+        if: (github.repository == 'OrcaSlicer/OrcaSlicer' || vars.ENABLE_SIGNING == 'true') && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') || vars.ENABLE_SIGNING == 'true') && runner.os == 'macOS' && inputs.macos-combine-only
         working-directory: ${{ github.workspace }}
         env:
           BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
@@ -217,7 +217,7 @@ jobs:
           fi
 
       - name: Create DMG without notary
-        if: github.ref != 'refs/heads/main' && runner.os == 'macOS' && inputs.macos-combine-only
+        if: github.ref != 'refs/heads/main' && vars.ENABLE_SIGNING != 'true' && runner.os == 'macOS' && inputs.macos-combine-only
         working-directory: ${{ github.workspace }}
         run: |
           mkdir -p ${{ github.workspace }}/build/universal/OrcaSlicer_dmg

--- a/.github/workflows/helio-release.yml
+++ b/.github/workflows/helio-release.yml
@@ -14,11 +14,12 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  # Gate: only run when a labeled PR is actually merged
+  # Gate: only run when a labeled, same-repo PR is actually merged
   check:
     if: >-
       github.event.pull_request.merged == true &&
-      contains(github.event.pull_request.labels.*.name, 'release')
+      contains(github.event.pull_request.labels.*.name, 'release') &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.ver.outputs.version }}
@@ -28,15 +29,25 @@ jobs:
       - name: Extract version from version.inc
         id: ver
         run: |
-          ver=$(grep 'set(SoftFever_VERSION' version.inc | cut -d '"' -f2)
+          set -euo pipefail
+          ver_line=$(grep 'set(SoftFever_VERSION' version.inc || true)
+          if [ -z "$ver_line" ]; then
+            echo "Error: Could not find SoftFever_VERSION in version.inc" >&2
+            exit 1
+          fi
+          ver=$(printf '%s\n' "$ver_line" | cut -d '"' -f2)
+          if [ -z "$ver" ]; then
+            echo "Error: Extracted empty version from version.inc" >&2
+            exit 1
+          fi
           echo "version=$ver" >> "$GITHUB_OUTPUT"
       - name: Determine release tag
         id: tag
         run: |
           tag="helio-v${{ steps.ver.outputs.version }}"
-          # If tag already exists, append short SHA to avoid collision
+          # If tag already exists, append short SHA of merge commit to avoid collision
           if git ls-remote --tags origin "refs/tags/$tag" | grep -q "refs/tags/$tag$"; then
-            tag="${tag}-$(echo ${{ github.sha }} | cut -c1-7)"
+            tag="${tag}-$(echo ${{ github.event.pull_request.merge_commit_sha }} | cut -c1-7)"
           fi
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
 
@@ -92,35 +103,44 @@ jobs:
 
       - name: Collect release assets
         run: |
+          set -euo pipefail
           mkdir -p release
+          missing=""
 
           # macOS universal DMG
           dmg=$(find artifacts -name 'OrcaSlicer_Mac_universal_*.dmg' -print -quit)
           if [ -n "$dmg" ]; then
             cp "$dmg" "release/OrcaSlicer_Helio_Mac_universal_${{ needs.check.outputs.version }}.dmg"
+          else
+            missing="$missing macOS-DMG"
           fi
 
           # Windows installer
           installer=$(find artifacts -name 'OrcaSlicer_Windows_Installer_*.exe' -print -quit)
           if [ -n "$installer" ]; then
             cp "$installer" "release/OrcaSlicer_Helio_Windows_Installer_${{ needs.check.outputs.version }}.exe"
+          else
+            missing="$missing Windows-Installer"
           fi
 
           # Windows portable — the artifact is a directory, re-zip it
           portable_dir=$(find artifacts -maxdepth 1 -type d -name 'OrcaSlicer_Windows_*_portable' -print -quit)
           if [ -n "$portable_dir" ]; then
             (cd "$portable_dir" && zip -r "$GITHUB_WORKSPACE/release/OrcaSlicer_Helio_Windows_${{ needs.check.outputs.version }}_portable.zip" .)
+          else
+            missing="$missing Windows-Portable"
           fi
 
           # Linux AppImage
           appimage=$(find artifacts -name 'OrcaSlicer_Linux_AppImage*.AppImage' -print -quit)
           if [ -n "$appimage" ]; then
             cp "$appimage" "release/OrcaSlicer_Helio_Linux_${{ needs.check.outputs.version }}.AppImage"
+          else
+            missing="$missing Linux-AppImage"
           fi
 
-          # Fail if no assets were collected
-          if ! ls release/* >/dev/null 2>&1; then
-            echo "Error: No release assets were collected."
+          if [ -n "$missing" ]; then
+            echo "Error: Missing release assets:$missing"
             exit 1
           fi
 

--- a/.github/workflows/helio-release.yml
+++ b/.github/workflows/helio-release.yml
@@ -1,0 +1,134 @@
+name: Helio Release
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - orca-latest-parity-bambu
+
+concurrency:
+  group: helio-release-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  # Gate: only run when a labeled PR is actually merged
+  check:
+    if: >-
+      github.event.pull_request.merged == true &&
+      contains(github.event.pull_request.labels.*.name, 'release')
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.ver.outputs.version }}
+      tag: ${{ steps.tag.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Extract version from version.inc
+        id: ver
+        run: |
+          ver=$(grep 'set(SoftFever_VERSION' version.inc | cut -d '"' -f2)
+          echo "version=$ver" >> "$GITHUB_OUTPUT"
+      - name: Determine release tag
+        id: tag
+        run: |
+          tag="helio-v${{ steps.ver.outputs.version }}"
+          # If tag already exists, append short SHA to avoid collision
+          if git ls-remote --tags origin "$tag" | grep -q "$tag"; then
+            tag="${tag}-$(echo ${{ github.sha }} | cut -c1-7)"
+          fi
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+  build_linux:
+    needs: check
+    uses: ./.github/workflows/build_check_cache.yml
+    with:
+      os: ubuntu-24.04
+    secrets: inherit
+
+  build_windows:
+    needs: check
+    uses: ./.github/workflows/build_check_cache.yml
+    with:
+      os: windows-latest
+    secrets: inherit
+
+  build_macos_arch:
+    needs: check
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [arm64, x86_64]
+    uses: ./.github/workflows/build_check_cache.yml
+    with:
+      os: macos-14
+      arch: ${{ matrix.arch }}
+    secrets: inherit
+
+  build_macos_universal:
+    needs: [check, build_macos_arch]
+    uses: ./.github/workflows/build_orca.yml
+    with:
+      os: macos-14
+      arch: universal
+      macos-combine-only: true
+    secrets: inherit
+
+  release:
+    needs: [check, build_linux, build_windows, build_macos_universal]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v7
+        with:
+          path: artifacts
+
+      - name: List artifacts
+        run: find artifacts -type f | head -50
+
+      - name: Collect release assets
+        run: |
+          mkdir -p release
+
+          # macOS universal DMG
+          dmg=$(find artifacts -name 'OrcaSlicer_Mac_universal_*.dmg' -print -quit)
+          if [ -n "$dmg" ]; then
+            cp "$dmg" "release/OrcaSlicer_Helio_Mac_universal_${{ needs.check.outputs.version }}.dmg"
+          fi
+
+          # Windows installer
+          installer=$(find artifacts -name 'OrcaSlicer_Windows_Installer_*.exe' -print -quit)
+          if [ -n "$installer" ]; then
+            cp "$installer" "release/OrcaSlicer_Helio_Windows_Installer_${{ needs.check.outputs.version }}.exe"
+          fi
+
+          # Windows portable — the artifact is a directory, re-zip it
+          portable_dir=$(find artifacts -maxdepth 1 -type d -name 'OrcaSlicer_Windows_*_portable' -print -quit)
+          if [ -n "$portable_dir" ]; then
+            (cd "$portable_dir" && zip -r "$GITHUB_WORKSPACE/release/OrcaSlicer_Helio_Windows_${{ needs.check.outputs.version }}_portable.zip" .)
+          fi
+
+          # Linux AppImage
+          appimage=$(find artifacts -name 'OrcaSlicer_Linux_AppImage*.AppImage' -print -quit)
+          if [ -n "$appimage" ]; then
+            cp "$appimage" "release/OrcaSlicer_Helio_Linux_${{ needs.check.outputs.version }}.AppImage"
+          fi
+
+          echo "Release assets:"
+          ls -lh release/
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.check.outputs.tag }}
+          name: "Helio v${{ needs.check.outputs.version }}"
+          body: |
+            ## OrcaSlicer with Helio Additive — v${{ needs.check.outputs.version }}
+
+            Released from PR #${{ github.event.pull_request.number }}: ${{ github.event.pull_request.title }}
+
+            ${{ github.event.pull_request.body }}
+          files: release/*
+          draft: false
+          prerelease: ${{ contains(needs.check.outputs.version, 'rc') || contains(needs.check.outputs.version, 'beta') }}
+          generate_release_notes: false

--- a/.github/workflows/helio-release.yml
+++ b/.github/workflows/helio-release.yml
@@ -101,6 +101,21 @@ jobs:
       - name: List artifacts
         run: find artifacts -type f | head -50
 
+      - name: Prepare release body
+        id: body
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          {
+            echo "content<<HELIO_EOF"
+            echo "## OrcaSlicer with Helio Additive — v${{ needs.check.outputs.version }}"
+            echo ""
+            echo "Released from PR #${{ github.event.pull_request.number }}: ${{ github.event.pull_request.title }}"
+            echo ""
+            echo "$PR_BODY"
+            echo "HELIO_EOF"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Collect release assets
         run: |
           set -euo pipefail
@@ -153,13 +168,14 @@ jobs:
           tag_name: ${{ needs.check.outputs.tag }}
           name: "Helio v${{ needs.check.outputs.version }}"
           target_commitish: ${{ github.event.pull_request.merge_commit_sha }}
-          body: |
-            ## OrcaSlicer with Helio Additive — v${{ needs.check.outputs.version }}
-
-            Released from PR #${{ github.event.pull_request.number }}: ${{ github.event.pull_request.title }}
-
-            ${{ github.event.pull_request.body }}
+          body: ${{ steps.body.outputs.content }}
           files: release/*
           draft: false
-          prerelease: ${{ contains(needs.check.outputs.version, 'rc') || contains(needs.check.outputs.version, 'beta') }}
+          prerelease: >-
+            ${{
+              contains(needs.check.outputs.version, 'rc') ||
+              contains(needs.check.outputs.version, 'RC') ||
+              contains(needs.check.outputs.version, 'beta') ||
+              contains(needs.check.outputs.version, 'Beta')
+            }}
           generate_release_notes: false

--- a/.github/workflows/helio-release.yml
+++ b/.github/workflows/helio-release.yml
@@ -1,7 +1,10 @@
 name: Helio Release
 
+# Uses pull_request (not pull_request_target) because all PRs originate from
+# branches within the same repo, so secrets and write permissions are available.
+# This also ensures reusable workflows check out the correct merge commit.
 on:
-  pull_request_target:
+  pull_request:
     types: [closed]
     branches:
       - orca-latest-parity-bambu
@@ -22,8 +25,6 @@ jobs:
       tag: ${{ steps.tag.outputs.tag }}
     steps:
       - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.merge_commit_sha }}
       - name: Extract version from version.inc
         id: ver
         run: |
@@ -35,7 +36,7 @@ jobs:
           tag="helio-v${{ steps.ver.outputs.version }}"
           # If tag already exists, append short SHA to avoid collision
           if git ls-remote --tags origin "refs/tags/$tag" | grep -q "refs/tags/$tag$"; then
-            tag="${tag}-$(echo ${{ github.event.pull_request.merge_commit_sha }} | cut -c1-7)"
+            tag="${tag}-$(echo ${{ github.sha }} | cut -c1-7)"
           fi
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
 
@@ -115,6 +116,12 @@ jobs:
           appimage=$(find artifacts -name 'OrcaSlicer_Linux_AppImage*.AppImage' -print -quit)
           if [ -n "$appimage" ]; then
             cp "$appimage" "release/OrcaSlicer_Helio_Linux_${{ needs.check.outputs.version }}.AppImage"
+          fi
+
+          # Fail if no assets were collected
+          if ! ls release/* >/dev/null 2>&1; then
+            echo "Error: No release assets were collected."
+            exit 1
           fi
 
           echo "Release assets:"

--- a/.github/workflows/helio-release.yml
+++ b/.github/workflows/helio-release.yml
@@ -1,7 +1,7 @@
 name: Helio Release
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
     branches:
       - orca-latest-parity-bambu
@@ -22,6 +22,8 @@ jobs:
       tag: ${{ steps.tag.outputs.tag }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
       - name: Extract version from version.inc
         id: ver
         run: |
@@ -32,8 +34,8 @@ jobs:
         run: |
           tag="helio-v${{ steps.ver.outputs.version }}"
           # If tag already exists, append short SHA to avoid collision
-          if git ls-remote --tags origin "$tag" | grep -q "$tag"; then
-            tag="${tag}-$(echo ${{ github.sha }} | cut -c1-7)"
+          if git ls-remote --tags origin "refs/tags/$tag" | grep -q "refs/tags/$tag$"; then
+            tag="${tag}-$(echo ${{ github.event.pull_request.merge_commit_sha }} | cut -c1-7)"
           fi
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
 
@@ -77,6 +79,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      actions: read
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@v7
@@ -122,6 +125,7 @@ jobs:
         with:
           tag_name: ${{ needs.check.outputs.tag }}
           name: "Helio v${{ needs.check.outputs.version }}"
+          target_commitish: ${{ github.event.pull_request.merge_commit_sha }}
           body: |
             ## OrcaSlicer with Helio Additive — v${{ needs.check.outputs.version }}
 


### PR DESCRIPTION
## Summary
- New `helio-release.yml` workflow that builds and publishes GitHub Releases when a PR with the `release` label is merged to `orca-latest-parity-bambu`
- Builds all 3 platforms (macOS universal, Windows, Linux) using existing reusable workflows
- Tags releases as `helio-v{version}` (e.g. `helio-v2.3.2-rc2`), with SHA suffix for collisions
- Marks RC/beta versions as pre-releases
- Update `build_orca.yml` to support macOS signing on forks via `ENABLE_SIGNING` repo variable

## Setup required
- Set repo variable `ENABLE_SIGNING=true` in GitHub Settings → Variables to enable macOS signing/notarization

## Test plan
- [ ] Merge a PR with `release` label → verify workflow triggers
- [ ] Verify all 3 platform builds complete
- [ ] Verify GitHub Release is created with correct tag and binaries
- [ ] Verify macOS DMG is signed and notarized (requires `ENABLE_SIGNING=true`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * More flexible macOS signing and notarization gating, and adjusted DMG handling for non-release runs.

* **New Features**
  * Added an automated release workflow that builds Linux/Windows/macOS (per-arch then universal), gathers artifacts, renames/versioned outputs, creates GitHub Releases, marks prereleases for rc/beta versions, and avoids tag collisions by appending commit info when needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->