### PR TITLE
Add manual dispatch trigger to Helio release workflow

### DIFF
--- a/.github/workflows/helio-release.yml
+++ b/.github/workflows/helio-release.yml
@@ -71,7 +71,7 @@ jobs:
             tag="helio-v${{ steps.ver.outputs.version }}"
           fi
           # If tag already exists, append short SHA to avoid collision
-          if git ls-remote --tags origin "refs/tags/$tag" | grep -q "refs/tags/$tag$"; then
+          if git ls-remote --tags origin "refs/tags/$tag" | grep -qF "refs/tags/$tag$"; then
             sha="${{ github.event.pull_request.merge_commit_sha || github.sha }}"
             tag="${tag}-$(echo $sha | cut -c1-7)"
           fi

--- a/.github/workflows/helio-release.yml
+++ b/.github/workflows/helio-release.yml
@@ -9,17 +9,26 @@ on:
     branches:
       - orca-latest-parity-bambu
 
+  workflow_dispatch:
+    inputs:
+      tag_override:
+        description: 'Optional tag name (default: helio-v{version})'
+        required: false
+
 concurrency:
-  group: helio-release-${{ github.event.pull_request.number }}
+  group: helio-release-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: false
 
 jobs:
-  # Gate: only run when a labeled, same-repo PR is actually merged
+  # Gate: for PR triggers, only run when a labeled, same-repo PR is actually merged
+  # For workflow_dispatch, always run
   check:
     if: >-
-      github.event.pull_request.merged == true &&
-      contains(github.event.pull_request.labels.*.name, 'release') &&
-      github.event.pull_request.head.repo.full_name == github.repository
+      github.event_name == 'workflow_dispatch' || (
+        github.event.pull_request.merged == true &&
+        contains(github.event.pull_request.labels.*.name, 'release') &&
+        github.event.pull_request.head.repo.full_name == github.repository
+      )
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.ver.outputs.version }}
@@ -44,10 +53,16 @@ jobs:
       - name: Determine release tag
         id: tag
         run: |
-          tag="helio-v${{ steps.ver.outputs.version }}"
-          # If tag already exists, append short SHA of merge commit to avoid collision
+          # Use override if provided, otherwise auto-generate
+          if [ -n "${{ inputs.tag_override }}" ]; then
+            tag="${{ inputs.tag_override }}"
+          else
+            tag="helio-v${{ steps.ver.outputs.version }}"
+          fi
+          # If tag already exists, append short SHA to avoid collision
           if git ls-remote --tags origin "refs/tags/$tag" | grep -q "refs/tags/$tag$"; then
-            tag="${tag}-$(echo ${{ github.event.pull_request.merge_commit_sha }} | cut -c1-7)"
+            sha="${{ github.event.pull_request.merge_commit_sha || github.sha }}"
+            tag="${tag}-$(echo $sha | cut -c1-7)"
           fi
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
 
@@ -104,13 +119,19 @@ jobs:
       - name: Prepare release body
         id: body
         env:
-          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_BODY: ${{ github.event.pull_request.body || '' }}
+          PR_NUMBER: ${{ github.event.pull_request.number || '' }}
+          PR_TITLE: ${{ github.event.pull_request.title || 'Manual release' }}
         run: |
           {
             echo "content<<HELIO_EOF"
             echo "## OrcaSlicer with Helio Additive — v${{ needs.check.outputs.version }}"
             echo ""
-            echo "Released from PR #${{ github.event.pull_request.number }}: ${{ github.event.pull_request.title }}"
+            if [ -n "$PR_NUMBER" ]; then
+              echo "Released from PR #${PR_NUMBER}: ${PR_TITLE}"
+            else
+              echo "Manual release from branch ${{ github.ref_name }}"
+            fi
             echo ""
             echo "$PR_BODY"
             echo "HELIO_EOF"
@@ -167,7 +188,7 @@ jobs:
         with:
           tag_name: ${{ needs.check.outputs.tag }}
           name: "Helio v${{ needs.check.outputs.version }}"
-          target_commitish: ${{ github.event.pull_request.merge_commit_sha }}
+          target_commitish: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
           body: ${{ steps.body.outputs.content }}
           files: release/*
           draft: false

--- a/.github/workflows/helio-release.yml
+++ b/.github/workflows/helio-release.yml
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
   # Gate: for PR triggers, only run when a labeled, same-repo PR is actually merged
-  # For workflow_dispatch, always run
+  # For workflow_dispatch, only run on the release branch
   check:
     if: >-
       (github.event_name == 'workflow_dispatch' &&
@@ -58,11 +58,12 @@ jobs:
         env:
           TAG_OVERRIDE: ${{ inputs.tag_override }}
         run: |
+          set -euo pipefail
           # Use override if provided, otherwise auto-generate
           if [ -n "$TAG_OVERRIDE" ]; then
-            # Validate: reject invalid tag characters (only allow alnum, dot, dash, underscore)
-            if ! printf '%s' "$TAG_OVERRIDE" | grep -qE '^[a-zA-Z0-9._-]+$'; then
-              echo "Error: tag_override contains invalid characters" >&2
+            # Validate using Git's own ref rules
+            if ! git check-ref-format --allow-onelevel "refs/tags/$TAG_OVERRIDE"; then
+              echo "Error: tag_override is not a valid Git tag name" >&2
               exit 1
             fi
             tag="$TAG_OVERRIDE"
@@ -133,8 +134,9 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number || '' }}
           PR_TITLE: ${{ github.event.pull_request.title || 'Manual release' }}
         run: |
+          delim="HELIO_EOF_$(openssl rand -hex 8)"
           {
-            echo "content<<HELIO_EOF"
+            echo "content<<$delim"
             echo "## OrcaSlicer with Helio Additive — v${{ needs.check.outputs.version }}"
             echo ""
             if [ -n "$PR_NUMBER" ]; then
@@ -144,7 +146,7 @@ jobs:
             fi
             echo ""
             echo "$PR_BODY"
-            echo "HELIO_EOF"
+            echo "$delim"
           } >> "$GITHUB_OUTPUT"
 
       - name: Collect release assets

--- a/.github/workflows/helio-release.yml
+++ b/.github/workflows/helio-release.yml
@@ -13,10 +13,12 @@ on:
     inputs:
       tag_override:
         description: 'Optional tag name (default: helio-v{version})'
+        type: string
         required: false
+        default: ''
 
 concurrency:
-  group: helio-release-${{ github.event.pull_request.number || github.run_id }}
+  group: helio-release-${{ github.event_name == 'workflow_dispatch' && github.ref_name || github.event.pull_request.number }}
   cancel-in-progress: false
 
 jobs:
@@ -24,7 +26,8 @@ jobs:
   # For workflow_dispatch, always run
   check:
     if: >-
-      github.event_name == 'workflow_dispatch' || (
+      (github.event_name == 'workflow_dispatch' &&
+        github.ref == 'refs/heads/orca-latest-parity-bambu') || (
         github.event.pull_request.merged == true &&
         contains(github.event.pull_request.labels.*.name, 'release') &&
         github.event.pull_request.head.repo.full_name == github.repository
@@ -52,10 +55,12 @@ jobs:
           echo "version=$ver" >> "$GITHUB_OUTPUT"
       - name: Determine release tag
         id: tag
+        env:
+          TAG_OVERRIDE: ${{ inputs.tag_override }}
         run: |
           # Use override if provided, otherwise auto-generate
-          if [ -n "${{ inputs.tag_override }}" ]; then
-            tag="${{ inputs.tag_override }}"
+          if [ -n "$TAG_OVERRIDE" ]; then
+            tag="$TAG_OVERRIDE"
           else
             tag="helio-v${{ steps.ver.outputs.version }}"
           fi

--- a/.github/workflows/helio-release.yml
+++ b/.github/workflows/helio-release.yml
@@ -60,6 +60,11 @@ jobs:
         run: |
           # Use override if provided, otherwise auto-generate
           if [ -n "$TAG_OVERRIDE" ]; then
+            # Validate: reject invalid tag characters (only allow alnum, dot, dash, underscore)
+            if ! printf '%s' "$TAG_OVERRIDE" | grep -qE '^[a-zA-Z0-9._-]+$'; then
+              echo "Error: tag_override contains invalid characters" >&2
+              exit 1
+            fi
             tag="$TAG_OVERRIDE"
           else
             tag="helio-v${{ steps.ver.outputs.version }}"


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch` trigger to `helio-release.yml` so releases can be triggered manually from the Actions UI
- Supports optional `tag_override` input for custom tag names
- All PR-specific references (`merge_commit_sha`, `body`, `number`, `title`) gracefully fall back when no PR context exists

## Test plan
- [ ] Merge this PR
- [ ] Go to Actions → Helio Release → Run workflow
- [ ] Verify the release builds trigger and complete successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a manual release trigger with an optional custom tag input and validation to reject invalid tag names.
  * Allow specifying a custom release tag for manual deployments and fallback to a SHA-based suffix on collisions.
  * Improved release notes generation to clearly indicate PR-based or manual releases and handle missing PR data.
  * Made release targeting and concurrency handling more robust across PR-merge and manual dispatch runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->