### PR TITLE
Add claude-work label to sync workflow

### DIFF
--- a/.github/workflows/helio-upstream-sync.yml
+++ b/.github/workflows/helio-upstream-sync.yml
@@ -321,7 +321,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               title: `Upstream sync failed: ${syncLabel} (merge conflicts)`,
-              labels: ['upstream-sync'],
+              labels: ['upstream-sync', 'claude-work'],
               body: body
             });
             console.log('Created merge conflict issue');
@@ -411,6 +411,14 @@ jobs:
               });
               core.setOutput('url', pr.html_url);
               console.log(`Created PR: ${pr.html_url}`);
+
+              // Add claude-work label for Cowork auto-triage
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                labels: ['claude-work']
+              });
             } catch (err) {
               const errMsg = err.message || '';
               const errData = err.response?.data;

--- a/.github/workflows/helio-upstream-sync.yml
+++ b/.github/workflows/helio-upstream-sync.yml
@@ -459,7 +459,35 @@ jobs:
               if (err.status === 422 && errMsgs.includes('No commits between')) {
                 console.log(`No diff between ${target} and ${branch} — skipping PR creation`);
               } else if (err.status === 422 && errMsgs.includes('already exists')) {
-                console.log(`PR already exists for ${branch} — skipping`);
+                console.log(`PR already exists for ${branch} — looking up existing PR to apply label`);
+                try {
+                  const { data: prs } = await github.rest.pulls.list({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    head: `${context.repo.owner}:${branch}`,
+                    base: target,
+                    state: 'open'
+                  });
+                  if (prs.length > 0) {
+                    const existingPr = prs[0];
+                    core.setOutput('url', existingPr.html_url);
+                    console.log(`Found existing PR #${existingPr.number}: ${existingPr.html_url}`);
+                    try {
+                      await github.rest.issues.addLabels({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        issue_number: existingPr.number,
+                        labels: ['claude-work']
+                      });
+                    } catch (labelErr) {
+                      console.warn(`Warning: failed to add claude-work label to existing PR #${existingPr.number}:`, labelErr);
+                    }
+                  } else {
+                    console.log(`Could not find existing open PR for ${branch} → ${target}`);
+                  }
+                } catch (listErr) {
+                  console.warn(`Warning: failed to list PRs for ${branch}:`, listErr);
+                }
               } else {
                 throw err;
               }

--- a/.github/workflows/helio-upstream-sync.yml
+++ b/.github/workflows/helio-upstream-sync.yml
@@ -412,6 +412,30 @@ jobs:
               return;
             }
 
+            // Ensure claude-work label exists before trying to apply it
+            try {
+              await github.rest.issues.getLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: 'claude-work'
+              });
+            } catch (e) {
+              if (e.status === 404) {
+                try {
+                  await github.rest.issues.createLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    name: 'claude-work',
+                    color: 'e4e669',
+                    description: 'Work item for Claude / Copilot'
+                  });
+                  console.log('Created missing label: claude-work');
+                } catch (createErr) {
+                  console.warn('Warning: could not create claude-work label:', createErr.message);
+                }
+              }
+            }
+
             const body = [
               `## Upstream Sync: ${syncLabel}`,
               '',

--- a/.github/workflows/helio-upstream-sync.yml
+++ b/.github/workflows/helio-upstream-sync.yml
@@ -413,12 +413,16 @@ jobs:
               console.log(`Created PR: ${pr.html_url}`);
 
               // Add claude-work label for Cowork auto-triage
-              await github.rest.issues.addLabels({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: pr.number,
-                labels: ['claude-work']
-              });
+              try {
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                  labels: ['claude-work']
+                });
+              } catch (labelErr) {
+                console.warn(`Warning: failed to add claude-work label to PR #${pr.number}:`, labelErr);
+              }
             } catch (err) {
               const errMsg = err.message || '';
               const errData = err.response?.data;

--- a/.github/workflows/helio-upstream-sync.yml
+++ b/.github/workflows/helio-upstream-sync.yml
@@ -317,6 +317,34 @@ jobs:
               'See `HELIO_INTEGRATION.md` for detailed conflict resolution rules.',
             ].join('\n');
 
+            // Ensure required labels exist before creating the issue; a missing
+            // label causes a 422 validation error that would suppress the issue.
+            const ensureLabel = async (name, color, description) => {
+              try {
+                await github.rest.issues.getLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name
+                });
+              } catch (e) {
+                if (e.status === 404) {
+                  await github.rest.issues.createLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    name,
+                    color,
+                    description
+                  });
+                  console.log(`Created missing label: ${name}`);
+                } else {
+                  console.warn(`Warning: could not verify label '${name}' (issue creation may fail): `, e.message);
+                }
+              }
+            };
+
+            await ensureLabel('upstream-sync', '0075ca', 'Upstream synchronisation tracking');
+            await ensureLabel('claude-work',   'e4e669', 'Work item for Claude / Copilot');
+
             await github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/helio-upstream-sync.yml
+++ b/.github/workflows/helio-upstream-sync.yml
@@ -328,16 +328,26 @@ jobs:
                 });
               } catch (e) {
                 if (e.status === 404) {
-                  await github.rest.issues.createLabel({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    name,
-                    color,
-                    description
-                  });
-                  console.log(`Created missing label: ${name}`);
+                  try {
+                    await github.rest.issues.createLabel({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      name,
+                      color,
+                      description
+                    });
+                    console.log(`Created missing label: ${name}`);
+                  } catch (createError) {
+                    console.warn(
+                      `Warning: could not create missing label '${name}' (issue will be created without this label): `,
+                      createError.message
+                    );
+                  }
                 } else {
-                  console.warn(`Warning: could not verify label '${name}' (issue creation may fail): `, e.message);
+                  console.warn(
+                    `Warning: could not verify label '${name}' (issue creation may fail): `,
+                    e.message
+                  );
                 }
               }
             };

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,8 +59,7 @@ cmake --build build/arm64 --config RelWithDebInfo --target all --
 ### Building on Linux
  **Always use this command to build the project when testing build issues on Linux.**
 ```bash
-cmake --build build/arm64 --config RelWithDebInfo --target all --
-
+cmake --build build/ --config RelWithDebInfo --target all --
 ```
 ### Build System
 - Uses CMake with minimum version 3.13 (maximum 3.31.x on Windows)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,38 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 This is the Helio-Additive fork of OrcaSlicer. For Helio integration details, conflict resolution rules during upstream syncs, and the complete file-by-file modification map, see **`HELIO_INTEGRATION.md`**.
 
+## CI/CD Workflows
+
+### Upstream Sync (`helio-upstream-sync.yml`)
+- Scheduled workflow that syncs upstream OrcaSlicer changes into `orca-latest-parity-bambu`
+- Auto-creates merge conflict issues (labeled `upstream-sync`, `claude-work`) when conflicts occur
+- Auto-creates sync PRs with changelog and Helio-relevant change reports
+- Uses `claude-work` label to flag items for automated triage
+
+### Upstream Watch (`helio-upstream-watch.yml`)
+- Monitors upstream for new tags/releases and creates tracking issues
+
+### Release (`helio-release.yml`)
+- Triggers on: merged PR with `release` label on `orca-latest-parity-bambu`, or manual `workflow_dispatch`
+- Builds all platforms (Linux, Windows, macOS universal) via reusable workflows
+- Creates GitHub Release with `Helio`-prefixed assets (DMG, AppImage, installer, portable zip)
+- Tag format: `helio-v{version}` (from `version.inc`)
+- Manual dispatch restricted to `orca-latest-parity-bambu` branch only
+
+### Build Pipeline (reusable workflows)
+- `build_check_cache.yml` → `build_deps.yml` → `build_orca.yml`
+- macOS signing/notarization gated by `ENABLE_SIGNING` repo variable
+- Dependency caching per OS/arch with hash of `deps/**`
+
+### Build All (`build_all.yml`)
+- Triggers on push/PR to `main` and `release/*` branches
+- Runs full build matrix + unit tests + Flatpak builds
+
+## Git Workflow
+- **Base branch**: `orca-latest-parity-bambu` (not `main`)
+- **Push remote**: `helio` (never `origin` — that's upstream OrcaSlicer)
+- **PRs target**: `orca-latest-parity-bambu`
+
 ## Overview
 
 OrcaSlicer is an open-source 3D slicer application forked from Bambu Studio, built using C++ with wxWidgets for the GUI and CMake as the build system. The project uses a modular architecture with separate libraries for core slicing functionality, GUI components, and platform-specific code.
@@ -30,27 +62,6 @@ cmake --build build/arm64 --config RelWithDebInfo --target all --
 cmake --build build/arm64 --config RelWithDebInfo --target all --
 
 ```
-### Build test:
-
-**Always use this command to build the project when testing build issues on Windows.**
-```bash
-cmake --build . --config %build_type% --target ALL_BUILD -- -m
-```
-
-### Building on macOS
-**Always use this command to build the project when testing build issues on macOS.**
-```bash
-cmake --build build/arm64 --config RelWithDebInfo --target all --
-```
-
-### Building on Linux
- **Always use this command to build the project when testing build issues on Linux.**
-```bash
-cmake --build build --config RelWithDebInfo --target all --
-
-```
-
-
 ### Build System
 - Uses CMake with minimum version 3.13 (maximum 3.31.x on Windows)
 - Primary build directory: `build/`

--- a/HELIO_INTEGRATION.md
+++ b/HELIO_INTEGRATION.md
@@ -4,7 +4,7 @@
 > This is the authoritative reference for AI agents resolving merge conflicts or build fixes.
 
 ## Stats
-- **61 files changed**: 29 new, 32 modified, 0 deleted
+- **64 files changed**: 32 new, 32 modified, 0 deleted
 - **+13,363 lines added, -195 lines removed**
 
 ## Architecture
@@ -29,7 +29,7 @@ Key data flow:
 - `HelioCompletionEvent` — carries result path + quality metrics to UI thread
 - Thermal Index — parsed from `;helioadditive=` gcode comments in `GCodeProcessor`
 
-## Helio-Only Files (29 files — NEVER exist upstream, always preserve)
+## Helio-Only Files (32 files — NEVER exist upstream, always preserve)
 
 ### Core API Client
 | File | Purpose |
@@ -41,7 +41,7 @@ Key data flow:
 | File | Purpose |
 |-|-|
 | `src/slic3r/GUI/HelioReleaseNote.hpp` | All Helio dialog declarations: `HelioInputDialog`, `HelioResultDialog`, `HelioStatusNotification` |
-| `src/slic3r/GUI/HelioReleaseNote.cpp` | Dialog implementations (4334 lines): mode selection, progress, results with TI visualization |
+| `src/slic3r/GUI/HelioReleaseNote.cpp` | Dialog implementations (4334 lines): mode selection, progress, results with TI visualization. `on_confirm()` calls `ShowExpandButton()` to show Helio button immediately after install (mirrors `on_uninstall()` hide logic) |
 | `src/slic3r/GUI/HelioHistoryDialog.hpp` | History dialog declaration |
 | `src/slic3r/GUI/HelioHistoryDialog.cpp` | History dialog: lists past Helio jobs, re-download results |
 
@@ -151,6 +151,9 @@ The heaviest modification. Contains the entire Helio processing pipeline.
 - **In tooltip render**: TI value display block (3 `append_table_row` calls)
 - **In status bar format**: 3 new `case` branches in switch statement
 
+#### `src/slic3r/GUI/GCodeViewer.hpp` (+7)
+- Syncs dropdown selection index when view type changes programmatically (prevents dropdown/view desync)
+
 #### `src/slic3r/GUI/LibVGCode/LibVGCodeWrapper.cpp` (+8/-8)
 - **4 positional initializer lists modified**: appended `curr.thermal_index_mean, curr.thermal_index_min, curr.thermal_index_max` to `PathVertex` aggregate initializations
 - Very fragile — if upstream changes `PathVertex` fields or reorders initializer, these break
@@ -167,13 +170,14 @@ The heaviest modification. Contains the entire Helio processing pipeline.
 - Added `push_helio_error_notification()` declaration
 - Modified signatures: `set_slicing_progress_began(bool is_helio = false)`, `set_slicing_progress_percentage(..., bool is_helio = false)`
 
-#### `src/slic3r/GUI/Preferences.cpp` (+65)
+#### `src/slic3r/GUI/Preferences.cpp` (+79)
 - Added `#include "../Utils/HelioDragon.hpp"`
 - **New "Helio" tab** appended to preferences: enable toggle, PAT input (password field), multi-material toggle, API URL display
+- **Toggle listener**: `enable_helio_processing` toggle immediately shows/hides the Helio button in MainFrame via `ShowExpandButton()` + `Layout()` (no restart required)
 
-#### `src/slic3r/GUI/GUI_App.cpp` (+26)
+#### `src/slic3r/GUI/GUI_App.cpp` (+28)
 - Added `#include "../Utils/HelioDragon.hpp"`
-- Startup initialization block: fetches supported data if helio enabled
+- Startup initialization block: always requests Helio supported data on startup (no "already loaded" guard)
 - New methods: `is_helio_enable()`, `request_helio_pat()`, `request_helio_supported_data()`
 
 #### `src/slic3r/GUI/GUI_App.hpp` (+4)
@@ -220,7 +224,7 @@ The heaviest modification. Contains the entire Helio processing pipeline.
 ### LOW RISK
 
 #### `src/libslic3r/AppConfig.cpp` (+25)
-- **Appended** defaults block in `set_defaults()`: `helio_api_url`, `enable_helio_processing`, `helio_api_china`, `helio_api_other`, `helio_multimaterial_enabled`, `helio_first_time_tutorial`
+- **Appended** defaults block in `set_defaults()`: `helio_api_url`, `enable_helio_processing` (defaults to `false`), `helio_api_china`, `helio_api_other`, `helio_multimaterial_enabled`, `helio_first_time_tutorial`
 
 #### `src/libslic3r/PrintBase.hpp` (+1)
 - Added `bool is_helio { false }` to `SlicingStatus` struct

--- a/HELIO_INTEGRATION.md
+++ b/HELIO_INTEGRATION.md
@@ -76,6 +76,13 @@ Key data flow:
 | `resources/web/helio/helio_service_snote_en.html` | Service notes (English) |
 | `resources/data/helio_hints.ini` | First-time tutorial hint text |
 
+### CI/CD Workflows (Helio-only)
+| File | Purpose |
+|-|-|
+| `.github/workflows/helio-release.yml` | Release workflow: builds all platforms, creates GitHub Release with Helio-prefixed assets. Triggers on merged PR with `release` label or manual `workflow_dispatch` (restricted to `orca-latest-parity-bambu`) |
+| `.github/workflows/helio-upstream-sync.yml` | Upstream sync: merges upstream changes, creates conflict issues (labeled `claude-work`), creates sync PRs |
+| `.github/workflows/helio-upstream-watch.yml` | Monitors upstream for new tags/releases, creates tracking issues |
+
 ## Modified Files (32 files — conflict risk, detailed per-file guide)
 
 ### CRITICAL RISK


### PR DESCRIPTION
## Summary
- Adds `claude-work` label to merge conflict issues created by `helio-upstream-sync.yml`
- Adds `claude-work` label to sync PRs after creation
- Enables Claude Desktop Cowork to auto-triage these items

## Test plan
- [ ] Verify `claude-work` label exists in repo
- [ ] Trigger a sync run and confirm label is applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflows now more reliably ensure and apply required labels when creating sync issues and PRs, and handle already-existing PRs gracefully.

* **Documentation**
  * Added CI/CD docs describing scheduled upstream syncs, release workflows, and upstream watch behavior; clarified recommended Git workflow and simplified build instructions.
  * Updated Helio integration docs to describe immediate show/hide of the Helio button via the UI toggle and related UI behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->