### PR TITLE
Fix slicer limits, unsupported printer enforcement, and Prepare tab enhance

### DIFF
--- a/src/slic3r/GUI/HelioReleaseNote.cpp
+++ b/src/slic3r/GUI/HelioReleaseNote.cpp
@@ -1995,7 +1995,8 @@ void HelioInputDialog::update_mode_card_styling(int selected_action)
     // velocity and volumetric speed fields
     auto double_min_checker = TextInputValChecker::CreateDoubleMinChecker(0);
 
-    // Read speed and volumetric limits from the active slicer config
+    // Read speed limits from active slicer config; min_volumetric_speed stays
+    // at 0 because OrcaSlicer has no "minimum volumetric speed" config setting.
     float min_speed = 0.0;
     float max_speed = 500.0;
     float min_volumetric_speed = 0.0;
@@ -2012,13 +2013,21 @@ void HelioInputDialog::update_mode_card_styling(int selected_action)
             "initial_layer_speed", "initial_layer_infill_speed",
             "ironing_speed", "skirt_speed"
         };
-        // FloatOrPercent keys — resolve percentage values using their base speeds
-        // when possible, otherwise only use absolute values
+        // FloatOrPercent keys — resolve percentage values using their base speeds.
+        // base_key is the config key that the percentage applies to.
+        // For scarf_joint_speed, G-code generation uses the slower of inner/outer
+        // wall speed; we resolve against outer_wall_speed (the slower default).
         struct FopKey { std::string key; std::string base_key; };
         const std::vector<FopKey> speed_keys_fop = {
             {"internal_bridge_speed", "bridge_speed"},
             {"small_perimeter_speed", "outer_wall_speed"},
-            {"scarf_joint_speed", ""}  // no clear base speed
+            {"scarf_joint_speed", "outer_wall_speed"},
+            // Overhang speeds (conditional on enable_overhang_speed, but included
+            // because they can be lower than wall speeds when active)
+            {"overhang_1_4_speed", "outer_wall_speed"},
+            {"overhang_2_4_speed", "outer_wall_speed"},
+            {"overhang_3_4_speed", "outer_wall_speed"},
+            {"overhang_4_4_speed", "outer_wall_speed"}
         };
         float cfg_min = std::numeric_limits<float>::max();
         float cfg_max = 0.0f;

--- a/src/slic3r/GUI/HelioReleaseNote.cpp
+++ b/src/slic3r/GUI/HelioReleaseNote.cpp
@@ -1957,24 +1957,53 @@ void HelioInputDialog::update_mode_card_styling(int selected_action)
     auto outerwall = create_print_priority_combo(card_optimization_settings);
 
     auto plater = Slic3r::GUI::wxGetApp().plater();
-    int layer_count = 0;
-    if (plater) {
-        // Try GCode viewer first (available on Preview tab)
-        auto* canvas = plater->get_current_canvas3D();
-        if (canvas)
-            layer_count = (int)canvas->get_gcode_layers_zs().size();
 
-        // Fall back to Print objects (works from Prepare tab after slicing)
-        // Use layers().size() (not total_layer_count()) to exclude support layers
-        if (layer_count == 0) {
-            const auto& print = plater->fff_print();
-            for (const auto* obj : print.objects()) {
-                int obj_layers = (int)obj->layers().size();
-                if (obj_layers > layer_count)
-                    layer_count = obj_layers;
+    // Read layer count, speed range, and volumetric rate range directly from
+    // the parsed G-code result. This works from both Prepare and Preview tabs
+    // and reflects actual G-code conditions (matching BambuStudio behavior).
+    int layer_count = 0;
+    float gcode_min_speed = 0.0f;
+    float gcode_max_speed = 0.0f;
+    float gcode_min_vol_rate = 0.0f;
+    float gcode_max_vol_rate = 0.0f;
+
+    if (plater) {
+        GCodeProcessorResult* gcode_result = plater->get_partplate_list().get_current_slice_result();
+        if (gcode_result && !gcode_result->moves.empty()) {
+            unsigned int max_layer_id = 0;
+            float speed_min = std::numeric_limits<float>::max();
+            float speed_max = 0.0f;
+            float vol_min = std::numeric_limits<float>::max();
+            float vol_max = 0.0f;
+
+            for (const auto& move : gcode_result->moves) {
+                // Only consider extrusion moves for speed/volumetric ranges
+                if (move.type != EMoveType::Extrude || move.extrusion_role == erNone)
+                    continue;
+
+                if (move.layer_id > max_layer_id)
+                    max_layer_id = move.layer_id;
+
+                if (move.feedrate > 0.0f) {
+                    speed_min = std::min(speed_min, move.feedrate);
+                    speed_max = std::max(speed_max, move.feedrate);
+                }
+
+                float vol_rate = move.volumetric_rate();
+                if (vol_rate > 0.0f) {
+                    vol_min = std::min(vol_min, vol_rate);
+                    vol_max = std::max(vol_max, vol_rate);
+                }
             }
+
+            layer_count = static_cast<int>(max_layer_id);
+            if (speed_min < std::numeric_limits<float>::max()) gcode_min_speed = speed_min;
+            if (speed_max > 0.0f) gcode_max_speed = speed_max;
+            if (vol_min < std::numeric_limits<float>::max()) gcode_min_vol_rate = vol_min;
+            if (vol_max > 0.0f) gcode_max_vol_rate = vol_max;
         }
     }
+
     // Clamp to at least 2 so the default UI range ("2 to N") is always valid,
     // even when the plate is unsliced or has only a single layer.
     int effective_layer_count = std::max(layer_count, 2);
@@ -1998,114 +2027,15 @@ void HelioInputDialog::update_mode_card_styling(int selected_action)
     // velocity and volumetric speed fields
     auto double_min_checker = TextInputValChecker::CreateDoubleMinChecker(0);
 
-    // Read speed limits from active slicer config; min_volumetric_speed stays
-    // at 0 because OrcaSlicer has no "minimum volumetric speed" config setting.
-    float min_speed = 0.0;
-    float max_speed = 500.0;
-    float min_volumetric_speed = 0.0;
-    float max_volumetric_speed = 30.0;
+    // Use the min/max speed and volumetric rate read from the parsed G-code
+    // result above. These reflect actual printing conditions from the G-code.
+    float min_speed = gcode_min_speed;
+    float max_speed = gcode_max_speed;
+    float min_volumetric_speed = gcode_min_vol_rate;
+    float max_volumetric_speed = gcode_max_vol_rate;
 
-    if (plater) {
-        const auto& print_config = plater->fff_print().full_print_config();
-        // Scan print speed settings to find actual min/max from the G-code config.
-        // Keep this list in sync with speed settings used by G-code generation.
-        const std::vector<std::string> speed_keys = {
-            "outer_wall_speed", "inner_wall_speed", "sparse_infill_speed",
-            "internal_solid_infill_speed", "top_surface_speed", "bridge_speed",
-            "support_speed", "support_interface_speed", "gap_infill_speed",
-            "initial_layer_speed", "initial_layer_infill_speed",
-            "ironing_speed", "skirt_speed"
-        };
-        // FloatOrPercent keys — resolve percentage values using their base speeds.
-        // base_key is the config key that the percentage applies to.
-        // scarf_joint_speed is resolved against both wall speeds because G-code
-        // generation applies it to inner and outer walls independently.
-        struct FopKey { std::string key; std::string base_key; };
-        const std::vector<FopKey> speed_keys_fop = {
-            {"internal_bridge_speed", "bridge_speed"},
-            {"small_perimeter_speed", "outer_wall_speed"},
-            {"scarf_joint_speed", "outer_wall_speed"},
-            {"scarf_joint_speed", "inner_wall_speed"},
-            // Overhang speeds (conditional on enable_overhang_speed, but included
-            // because they can be lower than wall speeds when active)
-            {"overhang_1_4_speed", "outer_wall_speed"},
-            {"overhang_2_4_speed", "outer_wall_speed"},
-            {"overhang_3_4_speed", "outer_wall_speed"},
-            {"overhang_4_4_speed", "outer_wall_speed"}
-        };
-        bool overhang_speed_enabled = false;
-        if (auto* overhang_opt = print_config.opt<ConfigOptionBool>("enable_overhang_speed"))
-            overhang_speed_enabled = overhang_opt->value;
-
-        float cfg_min = std::numeric_limits<float>::max();
-        float cfg_max = 0.0f;
-        for (const auto& key : speed_keys) {
-            auto* opt = print_config.opt<ConfigOptionFloat>(key);
-            if (opt && opt->value > 0) {
-                cfg_min = std::min(cfg_min, (float)opt->value);
-                cfg_max = std::max(cfg_max, (float)opt->value);
-            }
-        }
-        for (const auto& fop : speed_keys_fop) {
-            // Skip overhang speed keys when overhang speed is disabled
-            if (fop.key.rfind("overhang_", 0) == 0 && !overhang_speed_enabled)
-                continue;
-
-            auto* opt = print_config.opt<ConfigOptionFloatOrPercent>(fop.key);
-            if (!opt || opt->value <= 0)
-                continue;
-
-            double abs_value = 0.0;
-            if (!opt->percent) {
-                // Absolute value stored directly
-                abs_value = opt->value;
-            } else if (!fop.base_key.empty()) {
-                // Percentage — resolve using the base speed
-                auto* base_opt = print_config.opt<ConfigOptionFloat>(fop.base_key);
-                if (base_opt && base_opt->value > 0)
-                    abs_value = opt->get_abs_value(base_opt->value);
-            }
-
-            if (abs_value > 0.0) {
-                cfg_min = std::min(cfg_min, static_cast<float>(abs_value));
-                cfg_max = std::max(cfg_max, static_cast<float>(abs_value));
-            }
-        }
-        // small_perimeter_speed == 0 means "auto", which G-code generation
-        // treats as outer_wall_speed * 0.5. Include this implicit speed so
-        // min_speed reflects actual printing conditions.
-        {
-            auto* sp_opt = print_config.opt<ConfigOptionFloatOrPercent>("small_perimeter_speed");
-            if (sp_opt && sp_opt->value == 0) {
-                auto* outer_opt = print_config.opt<ConfigOptionFloat>("outer_wall_speed");
-                if (outer_opt && outer_opt->value > 0) {
-                    float auto_speed = static_cast<float>(outer_opt->value * 0.5);
-                    if (auto_speed > 0) {
-                        cfg_min = std::min(cfg_min, auto_speed);
-                        cfg_max = std::max(cfg_max, auto_speed);
-                    }
-                }
-            }
-        }
-        if (cfg_min < std::numeric_limits<float>::max() && cfg_min > 0)
-            min_speed = cfg_min;
-        if (cfg_max > 0)
-            max_speed = cfg_max;
-
-        // Read filament max volumetric speed — use the minimum positive value
-        // across all filament slots (safest limit for multi-material prints)
-        if (auto* vol_opt = print_config.opt<ConfigOptionFloats>("filament_max_volumetric_speed")) {
-            float cfg_max_vol = std::numeric_limits<float>::max();
-            for (double value : vol_opt->values) {
-                if (value > 0.0)
-                    cfg_max_vol = std::min(cfg_max_vol, static_cast<float>(value));
-            }
-            if (cfg_max_vol < std::numeric_limits<float>::max())
-                max_volumetric_speed = cfg_max_vol;
-        }
-    }
-
-    // velocity — use slicer config defaults
+    // velocity — populated from parsed G-code; only sent to backend when
+    // "Slicer default" limits mode is selected (see wxEVT_COMBOBOX handler below)
     wxBoxSizer* min_velocity_item = create_input_item(panel_velocity_volumetric, "min_velocity", _L("Min Velocity"), wxT("mm/s"), { double_min_checker } );
     m_input_items["min_velocity"]->GetTextCtrl()->SetLabel(wxString::Format("%.0f", s_round(min_speed, 0)));
 

--- a/src/slic3r/GUI/HelioReleaseNote.cpp
+++ b/src/slic3r/GUI/HelioReleaseNote.cpp
@@ -1975,7 +1975,10 @@ void HelioInputDialog::update_mode_card_styling(int selected_action)
             }
         }
     }
-    wxBoxSizer* layers_to_optimize_item = create_input_optimize_layers(card_optimization_settings, layer_count);
+    // Clamp to at least 2 so the default UI range ("2 to N") is always valid,
+    // even when the plate is unsliced or has only a single layer.
+    int effective_layer_count = std::max(layer_count, 2);
+    wxBoxSizer* layers_to_optimize_item = create_input_optimize_layers(card_optimization_settings, effective_layer_count);
 
     std::map<int, wxString> config_limits;
     config_limits[LIMITS_HELIO_DEFAULT] = _L("Helio default (recommended)");
@@ -2015,13 +2018,14 @@ void HelioInputDialog::update_mode_card_styling(int selected_action)
         };
         // FloatOrPercent keys — resolve percentage values using their base speeds.
         // base_key is the config key that the percentage applies to.
-        // For scarf_joint_speed, G-code generation uses the slower of inner/outer
-        // wall speed; we resolve against outer_wall_speed (the slower default).
+        // scarf_joint_speed is resolved against both wall speeds because G-code
+        // generation applies it to inner and outer walls independently.
         struct FopKey { std::string key; std::string base_key; };
         const std::vector<FopKey> speed_keys_fop = {
             {"internal_bridge_speed", "bridge_speed"},
             {"small_perimeter_speed", "outer_wall_speed"},
             {"scarf_joint_speed", "outer_wall_speed"},
+            {"scarf_joint_speed", "inner_wall_speed"},
             // Overhang speeds (conditional on enable_overhang_speed, but included
             // because they can be lower than wall speeds when active)
             {"overhang_1_4_speed", "outer_wall_speed"},
@@ -2065,6 +2069,22 @@ void HelioInputDialog::update_mode_card_styling(int selected_action)
             if (abs_value > 0.0) {
                 cfg_min = std::min(cfg_min, static_cast<float>(abs_value));
                 cfg_max = std::max(cfg_max, static_cast<float>(abs_value));
+            }
+        }
+        // small_perimeter_speed == 0 means "auto", which G-code generation
+        // treats as outer_wall_speed * 0.5. Include this implicit speed so
+        // min_speed reflects actual printing conditions.
+        {
+            auto* sp_opt = print_config.opt<ConfigOptionFloatOrPercent>("small_perimeter_speed");
+            if (sp_opt && sp_opt->value == 0) {
+                auto* outer_opt = print_config.opt<ConfigOptionFloat>("outer_wall_speed");
+                if (outer_opt && outer_opt->value > 0) {
+                    float auto_speed = static_cast<float>(outer_opt->value * 0.5);
+                    if (auto_speed > 0) {
+                        cfg_min = std::min(cfg_min, auto_speed);
+                        cfg_max = std::max(cfg_max, auto_speed);
+                    }
+                }
             }
         }
         if (cfg_min < std::numeric_limits<float>::max() && cfg_min > 0)

--- a/src/slic3r/GUI/HelioReleaseNote.cpp
+++ b/src/slic3r/GUI/HelioReleaseNote.cpp
@@ -1975,15 +1975,26 @@ void HelioInputDialog::update_mode_card_styling(int selected_action)
             float speed_max = 0.0f;
             float vol_min = std::numeric_limits<float>::max();
             float vol_max = 0.0f;
+            bool found_extrusion = false;
 
             for (const auto& move : gcode_result->moves) {
-                // Only consider extrusion moves for speed/volumetric ranges
+                // Only consider extrusion moves
                 if (move.type != EMoveType::Extrude || move.extrusion_role == erNone)
                     continue;
 
-                if (move.layer_id > max_layer_id)
-                    max_layer_id = move.layer_id;
+                // Exclude support/wipe-tower moves from layer count — these can
+                // extend past the last object layer and would inflate the range.
+                // Speed/volumetric ranges include all extrusion roles since they
+                // represent actual printing conditions.
+                if (move.extrusion_role != erSupportMaterial &&
+                    move.extrusion_role != erSupportMaterialInterface &&
+                    move.extrusion_role != erSupportTransition &&
+                    move.extrusion_role != erWipeTower) {
+                    if (move.layer_id > max_layer_id)
+                        max_layer_id = move.layer_id;
+                }
 
+                found_extrusion = true;
                 if (move.feedrate > 0.0f) {
                     speed_min = std::min(speed_min, move.feedrate);
                     speed_max = std::max(speed_max, move.feedrate);
@@ -1996,11 +2007,23 @@ void HelioInputDialog::update_mode_card_styling(int selected_action)
                 }
             }
 
-            layer_count = static_cast<int>(max_layer_id);
-            if (speed_min < std::numeric_limits<float>::max()) gcode_min_speed = speed_min;
-            if (speed_max > 0.0f) gcode_max_speed = speed_max;
-            if (vol_min < std::numeric_limits<float>::max()) gcode_min_vol_rate = vol_min;
-            if (vol_max > 0.0f) gcode_max_vol_rate = vol_max;
+            if (found_extrusion) {
+                layer_count = static_cast<int>(max_layer_id);
+                if (speed_min < std::numeric_limits<float>::max()) gcode_min_speed = speed_min;
+                if (speed_max > 0.0f) gcode_max_speed = speed_max;
+                if (vol_min < std::numeric_limits<float>::max()) gcode_min_vol_rate = vol_min;
+                if (vol_max > 0.0f) gcode_max_vol_rate = vol_max;
+            }
+        }
+
+        // Fallback: if no G-code result available, try Print objects
+        if (layer_count == 0) {
+            const auto& print = plater->fff_print();
+            for (const auto* obj : print.objects()) {
+                int obj_layers = static_cast<int>(obj->layers().size());
+                if (obj_layers > layer_count)
+                    layer_count = obj_layers;
+            }
         }
     }
 

--- a/src/slic3r/GUI/HelioReleaseNote.cpp
+++ b/src/slic3r/GUI/HelioReleaseNote.cpp
@@ -5,6 +5,8 @@
 #include "libslic3r/Utils.hpp"
 #include "libslic3r/Thread.hpp"
 #include "libslic3r/ExtrusionEntity.hpp"
+#include "libslic3r/Print.hpp"
+#include "libslic3r/PrintConfig.hpp"
 #include "GUI.hpp"
 #include "GUI_App.hpp"
 #include "GUI_Preview.hpp"
@@ -33,6 +35,7 @@ namespace GUI {
 #include <miniz.h>
 #include <wx/valnum.h>
 #include <algorithm>
+#include <limits>
 #include <climits>
 #include <cstdlib>
 #include <boost/algorithm/string.hpp>
@@ -1956,9 +1959,21 @@ void HelioInputDialog::update_mode_card_styling(int selected_action)
     auto plater = Slic3r::GUI::wxGetApp().plater();
     int layer_count = 0;
     if (plater) {
+        // Try GCode viewer first (available on Preview tab)
         auto* canvas = plater->get_current_canvas3D();
         if (canvas)
             layer_count = (int)canvas->get_gcode_layers_zs().size();
+
+        // Fall back to Print objects (works from Prepare tab after slicing)
+        // Use layers().size() (not total_layer_count()) to exclude support layers
+        if (layer_count == 0) {
+            const auto& print = plater->fff_print();
+            for (const auto* obj : print.objects()) {
+                int obj_layers = (int)obj->layers().size();
+                if (obj_layers > layer_count)
+                    layer_count = obj_layers;
+            }
+        }
     }
     wxBoxSizer* layers_to_optimize_item = create_input_optimize_layers(card_optimization_settings, layer_count);
 
@@ -1966,7 +1981,7 @@ void HelioInputDialog::update_mode_card_styling(int selected_action)
     config_limits[LIMITS_HELIO_DEFAULT] = _L("Helio default (recommended)");
     config_limits[LIMITS_SLICER_DEFAULT] = _L("Slicer default");
     auto limits = create_combo_item(card_optimization_settings, "limits", _L("Limits"), config_limits, LIMITS_HELIO_DEFAULT, LIMITS_DROPDOWN_WIDTH);
-    
+
     wxString limits_tooltip = _L("Set your own speed and flow rate limits - or rely on Helio's custom limit settings. With unsupported materials you need to supply your own data or rely on the slicer's built in data.");
     if (m_combo_items.find("limits") != m_combo_items.end()) {
         m_combo_items["limits"]->SetToolTip(limits_tooltip);
@@ -1980,9 +1995,80 @@ void HelioInputDialog::update_mode_card_styling(int selected_action)
     // velocity and volumetric speed fields
     auto double_min_checker = TextInputValChecker::CreateDoubleMinChecker(0);
 
-    // velocity — use slicer config defaults
+    // Read speed and volumetric limits from the active slicer config
     float min_speed = 0.0;
     float max_speed = 500.0;
+    float min_volumetric_speed = 0.0;
+    float max_volumetric_speed = 30.0;
+
+    if (plater) {
+        const auto& print_config = plater->fff_print().full_print_config();
+        // Scan print speed settings to find actual min/max from the G-code config.
+        // Keep this list in sync with speed settings used by G-code generation.
+        const std::vector<std::string> speed_keys = {
+            "outer_wall_speed", "inner_wall_speed", "sparse_infill_speed",
+            "internal_solid_infill_speed", "top_surface_speed", "bridge_speed",
+            "support_speed", "support_interface_speed", "gap_infill_speed",
+            "initial_layer_speed", "initial_layer_infill_speed",
+            "ironing_speed", "skirt_speed"
+        };
+        // FloatOrPercent keys — resolve percentage values using their base speeds
+        // when possible, otherwise only use absolute values
+        struct FopKey { std::string key; std::string base_key; };
+        const std::vector<FopKey> speed_keys_fop = {
+            {"internal_bridge_speed", "bridge_speed"},
+            {"small_perimeter_speed", "outer_wall_speed"},
+            {"scarf_joint_speed", ""}  // no clear base speed
+        };
+        float cfg_min = std::numeric_limits<float>::max();
+        float cfg_max = 0.0f;
+        for (const auto& key : speed_keys) {
+            auto* opt = print_config.opt<ConfigOptionFloat>(key);
+            if (opt && opt->value > 0) {
+                cfg_min = std::min(cfg_min, (float)opt->value);
+                cfg_max = std::max(cfg_max, (float)opt->value);
+            }
+        }
+        for (const auto& fop : speed_keys_fop) {
+            auto* opt = print_config.opt<ConfigOptionFloatOrPercent>(fop.key);
+            if (!opt || opt->value <= 0)
+                continue;
+
+            double abs_value = 0.0;
+            if (!opt->percent) {
+                // Absolute value stored directly
+                abs_value = opt->value;
+            } else if (!fop.base_key.empty()) {
+                // Percentage — resolve using the base speed
+                auto* base_opt = print_config.opt<ConfigOptionFloat>(fop.base_key);
+                if (base_opt && base_opt->value > 0)
+                    abs_value = opt->get_abs_value(base_opt->value);
+            }
+
+            if (abs_value > 0.0) {
+                cfg_min = std::min(cfg_min, static_cast<float>(abs_value));
+                cfg_max = std::max(cfg_max, static_cast<float>(abs_value));
+            }
+        }
+        if (cfg_min < std::numeric_limits<float>::max() && cfg_min > 0)
+            min_speed = cfg_min;
+        if (cfg_max > 0)
+            max_speed = cfg_max;
+
+        // Read filament max volumetric speed — use the minimum positive value
+        // across all filament slots (safest limit for multi-material prints)
+        if (auto* vol_opt = print_config.opt<ConfigOptionFloats>("filament_max_volumetric_speed")) {
+            float cfg_max_vol = std::numeric_limits<float>::max();
+            for (double value : vol_opt->values) {
+                if (value > 0.0)
+                    cfg_max_vol = std::min(cfg_max_vol, static_cast<float>(value));
+            }
+            if (cfg_max_vol < std::numeric_limits<float>::max())
+                max_volumetric_speed = cfg_max_vol;
+        }
+    }
+
+    // velocity — use slicer config defaults
     wxBoxSizer* min_velocity_item = create_input_item(panel_velocity_volumetric, "min_velocity", _L("Min Velocity"), wxT("mm/s"), { double_min_checker } );
     m_input_items["min_velocity"]->GetTextCtrl()->SetLabel(wxString::Format("%.0f", s_round(min_speed, 0)));
 
@@ -1990,8 +2076,6 @@ void HelioInputDialog::update_mode_card_styling(int selected_action)
     m_input_items["max_velocity"]->GetTextCtrl()->SetLabel(wxString::Format("%.0f", s_round(max_speed, 0)));
 
     // volumetric speed — use slicer config defaults
-    float min_volumetric_speed = 0.0;
-    float max_volumetric_speed = 30.0;
     wxBoxSizer* min_volumetric_speed_item = create_input_item(panel_velocity_volumetric, "min_volumetric_speed", _L("Min Volumetric Speed"), wxT("mm\u00B3/s"), { double_min_checker });
     m_input_items["min_volumetric_speed"]->GetTextCtrl()->SetLabel(wxString::Format("%.2f", s_round(min_volumetric_speed, 2)));
 

--- a/src/slic3r/GUI/HelioReleaseNote.cpp
+++ b/src/slic3r/GUI/HelioReleaseNote.cpp
@@ -2029,6 +2029,10 @@ void HelioInputDialog::update_mode_card_styling(int selected_action)
             {"overhang_3_4_speed", "outer_wall_speed"},
             {"overhang_4_4_speed", "outer_wall_speed"}
         };
+        bool overhang_speed_enabled = false;
+        if (auto* overhang_opt = print_config.opt<ConfigOptionBool>("enable_overhang_speed"))
+            overhang_speed_enabled = overhang_opt->value;
+
         float cfg_min = std::numeric_limits<float>::max();
         float cfg_max = 0.0f;
         for (const auto& key : speed_keys) {
@@ -2039,6 +2043,10 @@ void HelioInputDialog::update_mode_card_styling(int selected_action)
             }
         }
         for (const auto& fop : speed_keys_fop) {
+            // Skip overhang speed keys when overhang speed is disabled
+            if (fop.key.rfind("overhang_", 0) == 0 && !overhang_speed_enabled)
+                continue;
+
             auto* opt = print_config.opt<ConfigOptionFloatOrPercent>(fop.key);
             if (!opt || opt->value <= 0)
                 continue;

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -4301,6 +4301,7 @@ struct Plater::priv
     bool                        helio_elements_fetched = false;
     bool                        helio_processing_disabled = false;
     bool                        helio_using_reference_material { false };
+    bool                        helio_using_reference_printer { false };
     bool suppressed_backround_processing_update { false };
 
     // TODO: A mechanism would be useful for blocking the plater interactions:
@@ -10404,6 +10405,7 @@ private:
 int Plater::priv::update_helio_background_process_v2(std::string& printer_id, std::string& material_id)
 {
     helio_using_reference_material = false;
+    helio_using_reference_printer = false;
     notification_manager->close_notification_of_type(NotificationType::HelioSlicingError);
     PresetBundle* preset_bundle = wxGetApp().preset_bundle;
     std::string preset_name = preset_bundle->printers.get_edited_preset().name;
@@ -10427,7 +10429,6 @@ int Plater::priv::update_helio_background_process_v2(std::string& printer_id, st
     }
 
     bool helio_support = false;
-    bool helio_using_reference_printer = false;
 
     // Step 1: Try word-boundary matching
     auto [best_match_id, best_match_length] = match_printer_with_boundaries(
@@ -10799,6 +10800,7 @@ int Plater::priv::update_helio_background_process(std::string& printer_id,
                                                    bool& is_multi_color, bool& is_multi_material)
 {
     helio_using_reference_material = false;
+    helio_using_reference_printer = false;
     notification_manager->close_notification_of_type(NotificationType::HelioSlicingError);
     PresetBundle* preset_bundle = wxGetApp().preset_bundle;
     std::string preset_name = preset_bundle->printers.get_edited_preset().name;
@@ -10873,6 +10875,7 @@ int Plater::priv::update_helio_background_process(std::string& printer_id,
                 if (selection >= 0 && selection < (int)printer_ids.size()) {
                     printer_id = printer_ids[selection];
                     helio_support = true;
+                    helio_using_reference_printer = true;
                 }
             }
 
@@ -11106,8 +11109,8 @@ void Plater::priv::on_helio_process()
             );
         }
 
-        // If user selected a reference material, force "Slicer default" limits
-        if (helio_using_reference_material) {
+        // If user selected a reference material or reference printer, force "Slicer default" limits
+        if (helio_using_reference_material || helio_using_reference_printer) {
             dlg.set_force_slicer_default(true);
         }
 


### PR DESCRIPTION
## Summary

Fixes three `claude-work` bugs related to the Helio Enhance/Optimize workflow:

- **#41 — Slicer limits lower values always default to 0**: Min/max speed and volumetric flow rate limits are now read from the active slicer print config instead of being hardcoded to 0/500 mm/s and 0/30 mm³/s. Scans 13 `ConfigOptionFloat` speed keys plus 3 `ConfigOptionFloatOrPercent` keys (`internal_bridge_speed`, `small_perimeter_speed`, `scarf_joint_speed`) with percentage resolution via their respective base speeds. Volumetric speed uses the minimum positive value across all filament slots (safest for multi-material). This matches Bambu Studio behavior where limits reflect actual G-code conditions.

- **#40 — Slicer defaults not enforced for unsupported printer**: `helio_using_reference_printer` was a local variable that never propagated to the dialog. Promoted it to a `Plater::priv` member (like `helio_using_reference_material`), set in both V2 and V3 update functions, and checked in `on_helio_process()` to force slicer default limits mode.

- **#39 — Cannot start Enhance from Prepare tab (layer range "2 to 0")**: When the GCode viewer returns 0 layers (Prepare tab), falls back to `Print` objects' `layers().size()` (excluding support layers) to get the correct layer count.

### Improvements over closed PR #42
- FloatOrPercent speed options now resolve percentage values using their base speeds (e.g. `internal_bridge_speed` at 150% of `bridge_speed` is converted to absolute mm/s), addressing Copilot's review feedback
- PR description correctly documents `layers().size()` (not `total_layer_count()`)

Closes #39, closes #40, closes #41

## Test plan

- [ ] Open a sliced project, switch to **Prepare tab**, click Helio button → Enhance should show correct layer range (e.g. "2 to N"), not "2 to 0"
- [ ] Select **Slicer default** limits mode → Min/Max Velocity and Volumetric Speed fields should reflect actual print config values, not 0/500 and 0/30
- [ ] Select an **unsupported printer** (reference printer flow) → Enhance dialog should force "Slicer default" mode with dropdown disabled
- [ ] Select an **unsupported material** → same forced slicer default behavior (regression check)
- [ ] Supported printer + supported material → "Helio default (recommended)" should still be the default selection
- [ ] With a multi-material print, volumetric speed limit should use the most restrictive filament's value

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Speed and volumetric flow limits now derive from parsed G-code ranges instead of hardcoded defaults.
  * Reference-printer detection added to background processing; “force slicer default” applies when either reference material or reference printer is active.

* **Bug Fixes**
  * Improved layer-count calculation using parsed move data with a reliable fallback.
  * “Layers to optimize” range clamped to a minimum of 2 to avoid invalid defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->