### PR TITLE
ci: don't auto-trigger full build on PRs to orca-latest-parity-bambu

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -54,10 +54,14 @@ jobs:
   build_linux:
     strategy:
       fail-fast: false
-    # Don't run scheduled builds on forks; require 'ready-to-build' label for PRs to orca-latest-parity-bambu:
+    # Don't run scheduled builds on forks; for labeled events only run on ready-to-build for parity branch:
     if: >-
       ${{ !cancelled()
       && (github.event_name != 'schedule' || github.repository == 'OrcaSlicer/OrcaSlicer')
+      && (github.event_name != 'pull_request'
+          || github.event.action != 'labeled'
+          || (github.event.pull_request.base.ref == 'orca-latest-parity-bambu'
+              && github.event.label.name == 'ready-to-build'))
       && (github.event_name != 'pull_request'
           || github.event.pull_request.base.ref != 'orca-latest-parity-bambu'
           || contains(github.event.pull_request.labels.*.name, 'ready-to-build'))
@@ -68,10 +72,14 @@ jobs:
       build-deps-only: ${{ inputs.build-deps-only || false }}
     secrets: inherit
   build_windows:
-    # Don't run scheduled builds on forks; require 'ready-to-build' label for PRs to orca-latest-parity-bambu:
+    # Don't run scheduled builds on forks; for labeled events only run on ready-to-build for parity branch:
     if: >-
       ${{ !cancelled()
       && (github.event_name != 'schedule' || github.repository == 'OrcaSlicer/OrcaSlicer')
+      && (github.event_name != 'pull_request'
+          || github.event.action != 'labeled'
+          || (github.event.pull_request.base.ref == 'orca-latest-parity-bambu'
+              && github.event.label.name == 'ready-to-build'))
       && (github.event_name != 'pull_request'
           || github.event.pull_request.base.ref != 'orca-latest-parity-bambu'
           || contains(github.event.pull_request.labels.*.name, 'ready-to-build'))
@@ -89,10 +97,14 @@ jobs:
         arch:
           - arm64
           - x86_64
-    # Don't run scheduled builds on forks; require 'ready-to-build' label for PRs to orca-latest-parity-bambu:
+    # Don't run scheduled builds on forks; for labeled events only run on ready-to-build for parity branch:
     if: >-
       ${{ !cancelled()
       && (github.event_name != 'schedule' || github.repository == 'OrcaSlicer/OrcaSlicer')
+      && (github.event_name != 'pull_request'
+          || github.event.action != 'labeled'
+          || (github.event.pull_request.base.ref == 'orca-latest-parity-bambu'
+              && github.event.label.name == 'ready-to-build'))
       && (github.event_name != 'pull_request'
           || github.event.pull_request.base.ref != 'orca-latest-parity-bambu'
           || contains(github.event.pull_request.labels.*.name, 'ready-to-build'))
@@ -179,10 +191,14 @@ jobs:
             runner: ubuntu-24.04
           - arch: aarch64
             runner: ubuntu-24.04-arm
-    # Don't run scheduled builds on forks; skip on self-hosted; require 'ready-to-build' for PRs to orca-latest-parity-bambu:
+    # Don't run scheduled builds on forks; skip on self-hosted; for labeled events only run on ready-to-build for parity branch:
     if: >-
       ${{ !cancelled() && !vars.SELF_HOSTED
       && (github.event_name != 'schedule' || github.repository == 'OrcaSlicer/OrcaSlicer')
+      && (github.event_name != 'pull_request'
+          || github.event.action != 'labeled'
+          || (github.event.pull_request.base.ref == 'orca-latest-parity-bambu'
+              && github.event.label.name == 'ready-to-build'))
       && (github.event_name != 'pull_request'
           || github.event.pull_request.base.ref != 'orca-latest-parity-bambu'
           || contains(github.event.pull_request.labels.*.name, 'ready-to-build'))

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -17,9 +17,11 @@ on:
      - 'scripts/flatpak/**'
 
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
     branches:
      - main
      - release/*
+     - orca-latest-parity-bambu
     paths:
      - 'deps/**'
      - 'deps_src/**'
@@ -52,16 +54,28 @@ jobs:
   build_linux:
     strategy:
       fail-fast: false
-    # Don't run scheduled builds on forks:
-    if: ${{ !cancelled() && (github.event_name != 'schedule' || github.repository == 'OrcaSlicer/OrcaSlicer') }}
+    # Don't run scheduled builds on forks; require 'ready-to-build' label for PRs to orca-latest-parity-bambu:
+    if: >-
+      ${{ !cancelled()
+      && (github.event_name != 'schedule' || github.repository == 'OrcaSlicer/OrcaSlicer')
+      && (github.event_name != 'pull_request'
+          || github.event.pull_request.base.ref != 'orca-latest-parity-bambu'
+          || contains(github.event.pull_request.labels.*.name, 'ready-to-build'))
+      }}
     uses: ./.github/workflows/build_check_cache.yml
     with:
       os: ${{ vars.SELF_HOSTED && 'orca-lnx-server' || 'ubuntu-24.04' }}
       build-deps-only: ${{ inputs.build-deps-only || false }}
     secrets: inherit
   build_windows:
-    # Don't run scheduled builds on forks:
-    if: ${{ !cancelled() && (github.event_name != 'schedule' || github.repository == 'OrcaSlicer/OrcaSlicer') }}
+    # Don't run scheduled builds on forks; require 'ready-to-build' label for PRs to orca-latest-parity-bambu:
+    if: >-
+      ${{ !cancelled()
+      && (github.event_name != 'schedule' || github.repository == 'OrcaSlicer/OrcaSlicer')
+      && (github.event_name != 'pull_request'
+          || github.event.pull_request.base.ref != 'orca-latest-parity-bambu'
+          || contains(github.event.pull_request.labels.*.name, 'ready-to-build'))
+      }}
     uses: ./.github/workflows/build_check_cache.yml
     with:
       os: ${{ vars.SELF_HOSTED && 'orca-win-server' || 'windows-latest' }}
@@ -75,8 +89,14 @@ jobs:
         arch:
           - arm64
           - x86_64
-    # Don't run scheduled builds on forks:
-    if: ${{ !cancelled() && (github.event_name != 'schedule' || github.repository == 'OrcaSlicer/OrcaSlicer') }}
+    # Don't run scheduled builds on forks; require 'ready-to-build' label for PRs to orca-latest-parity-bambu:
+    if: >-
+      ${{ !cancelled()
+      && (github.event_name != 'schedule' || github.repository == 'OrcaSlicer/OrcaSlicer')
+      && (github.event_name != 'pull_request'
+          || github.event.pull_request.base.ref != 'orca-latest-parity-bambu'
+          || contains(github.event.pull_request.labels.*.name, 'ready-to-build'))
+      }}
     uses: ./.github/workflows/build_check_cache.yml
     with:
       os: ${{ vars.SELF_HOSTED && 'orca-macos-arm64' || 'macos-14' }}
@@ -159,8 +179,14 @@ jobs:
             runner: ubuntu-24.04
           - arch: aarch64
             runner: ubuntu-24.04-arm
-    # Don't run scheduled builds on forks; skip entirely on self-hosted runners
-    if: ${{ !cancelled() && !vars.SELF_HOSTED && (github.event_name != 'schedule' || github.repository == 'OrcaSlicer/OrcaSlicer') }}
+    # Don't run scheduled builds on forks; skip on self-hosted; require 'ready-to-build' for PRs to orca-latest-parity-bambu:
+    if: >-
+      ${{ !cancelled() && !vars.SELF_HOSTED
+      && (github.event_name != 'schedule' || github.repository == 'OrcaSlicer/OrcaSlicer')
+      && (github.event_name != 'pull_request'
+          || github.event.pull_request.base.ref != 'orca-latest-parity-bambu'
+          || contains(github.event.pull_request.labels.*.name, 'ready-to-build'))
+      }}
     runs-on: ${{ matrix.variant.runner }}
     env:
       date:

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -20,7 +20,6 @@ on:
     branches:
      - main
      - release/*
-     - orca-latest-parity-bambu
     paths:
      - 'deps/**'
      - 'deps_src/**'


### PR DESCRIPTION
## Summary

Gates the full build matrix for PRs targeting `orca-latest-parity-bambu` behind a `ready-to-build` label. This prevents CI from burning resources on every PR push while reviews are still in progress.

**How it works:**
- `pull_request` trigger now includes `types: [labeled]` alongside `opened/synchronize/reopened`
- Each build job (`build_linux`, `build_windows`, `build_macos_arch`, `flatpak`) checks: if the PR targets `orca-latest-parity-bambu`, the `ready-to-build` label must be present
- PRs targeting `main` / `release/*` are **unaffected** — they build on every push as before
- Post-merge `push` builds to `orca-latest-parity-bambu` are **unaffected**

**Workflow:**
1. Open PR → automated reviews (Copilot, CodeRabbit) run
2. Address feedback, iterate
3. Reviews clean → apply `ready-to-build` label → full build triggers
4. Build passes → ready for merge

## Test plan

- [ ] Open a PR targeting `orca-latest-parity-bambu` with `src/` changes → verify build does NOT auto-trigger
- [ ] Apply `ready-to-build` label to that PR → verify build triggers
- [ ] Verify PRs targeting `main` still auto-trigger builds without the label

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflow now triggers on PR label changes in addition to open/synchronize/reopen events.
  * Builds respect a new `ready-to-build` label for a selective base branch, preventing unnecessary runs.
  * Existing scheduled-build and Flatpak runner restrictions were preserved.
  * Workflow condition expressions were reformatted for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->