### PR TITLE
Redirect version check popup to Helio fork releases

### DIFF
--- a/src/libslic3r/AppConfig.cpp
+++ b/src/libslic3r/AppConfig.cpp
@@ -39,7 +39,7 @@ using namespace nlohmann;
 
 namespace Slic3r {
 
-static const std::string VERSION_CHECK_URL = "https://api.github.com/repos/Helio-Additive/OrcaSlicer/releases";
+static const std::string VERSION_CHECK_URL = "https://api.github.com/repos/Helio-Additive/OrcaSlicer/releases?per_page=100";
 static const std::string PROFILE_UPDATE_URL = "https://api.github.com/repos/OrcaSlicer/orcaslicer-profiles/releases/tags";
 static const std::string MODELS_STR = "models";
 

--- a/src/libslic3r/AppConfig.cpp
+++ b/src/libslic3r/AppConfig.cpp
@@ -39,7 +39,7 @@ using namespace nlohmann;
 
 namespace Slic3r {
 
-static const std::string VERSION_CHECK_URL = "https://check-version.orcaslicer.com/latest";
+static const std::string VERSION_CHECK_URL = "https://api.github.com/repos/Helio-Additive/OrcaSlicer/releases";
 static const std::string PROFILE_UPDATE_URL = "https://api.github.com/repos/OrcaSlicer/orcaslicer-profiles/releases/tags";
 static const std::string MODELS_STR = "models";
 

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -2995,7 +2995,7 @@ bool GUI_App::on_init_inner()
                 wxString tips = wxString::Format(_L("Click to download new version in default browser: %s"), version_str);
                 DownloadDialog dialog(this->mainframe,
                     tips,
-                    _L("Helio OrcaSlicer needs an upgrade"),
+                    _L("Helio Orca Slicer needs an upgrade"),
                     false,
                     wxCENTER | wxICON_INFORMATION);
                 dialog.SetExtendedMessage(description_text);
@@ -5403,6 +5403,10 @@ void GUI_App::check_new_version_sf(bool show_tips, int by_user)
             auto consider_release = [&](const boost::property_tree::ptree& node) {
                 auto tag_opt = node.get_optional<std::string>("tag_name");
                 if (!tag_opt)
+                    return;
+
+                // Skip draft releases (GitHub API returns them but they aren't published)
+                if (node.get_optional<bool>("draft").get_value_or(false))
                     return;
 
                 std::string tag = *tag_opt;

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -2995,7 +2995,7 @@ bool GUI_App::on_init_inner()
                 wxString tips = wxString::Format(_L("Click to download new version in default browser: %s"), version_str);
                 DownloadDialog dialog(this->mainframe,
                     tips,
-                    _L("The Orca Slicer needs an upgrade"),
+                    _L("Helio OrcaSlicer needs an upgrade"),
                     false,
                     wxCENTER | wxICON_INFORMATION);
                 dialog.SetExtendedMessage(description_text);
@@ -5406,7 +5406,12 @@ void GUI_App::check_new_version_sf(bool show_tips, int by_user)
                     return;
 
                 std::string tag = *tag_opt;
-                if (!tag.empty() && tag.front() == 'v')
+                // Strip Helio tag prefix (helio-v1.2.3 → 1.2.3)
+                const std::string helio_prefix = "helio-v";
+                if (tag.size() > helio_prefix.size() &&
+                    tag.compare(0, helio_prefix.size(), helio_prefix) == 0)
+                    tag.erase(0, helio_prefix.size());
+                else if (!tag.empty() && tag.front() == 'v')
                     tag.erase(0, 1);
 
                 Semver tag_version = get_version(tag, matcher);

--- a/src/slic3r/GUI/ReleaseNote.cpp
+++ b/src/slic3r/GUI/ReleaseNote.cpp
@@ -235,7 +235,7 @@ void UpdatePluginDialog::update_info(std::string json_path)
 }
 
 UpdateVersionDialog::UpdateVersionDialog(wxWindow *parent)
-    : DPIDialog(parent, wxID_ANY, _L("New version of Helio OrcaSlicer"), wxDefaultPosition, wxDefaultSize, wxCAPTION | wxCLOSE_BOX | wxRESIZE_BORDER)
+    : DPIDialog(parent, wxID_ANY, _L("New version of Helio Orca Slicer"), wxDefaultPosition, wxDefaultSize, wxCAPTION | wxCLOSE_BOX | wxRESIZE_BORDER)
 {
     SetBackgroundColour(*wxWHITE);
 

--- a/src/slic3r/GUI/ReleaseNote.cpp
+++ b/src/slic3r/GUI/ReleaseNote.cpp
@@ -235,7 +235,7 @@ void UpdatePluginDialog::update_info(std::string json_path)
 }
 
 UpdateVersionDialog::UpdateVersionDialog(wxWindow *parent)
-    : DPIDialog(parent, wxID_ANY, _L("New version of Orca Slicer"), wxDefaultPosition, wxDefaultSize, wxCAPTION | wxCLOSE_BOX | wxRESIZE_BORDER)
+    : DPIDialog(parent, wxID_ANY, _L("New version of Helio OrcaSlicer"), wxDefaultPosition, wxDefaultSize, wxCAPTION | wxCLOSE_BOX | wxRESIZE_BORDER)
 {
     SetBackgroundColour(*wxWHITE);
 


### PR DESCRIPTION
# Description\n\nFixes #46 — The \"new version available\" popup was showing upstream OrcaSlicer releases instead of Helio's own releases.\n\n## Changes\n\n1. **`src/libslic3r/AppConfig.cpp`**: Changed `VERSION_CHECK_URL` from `https://check-version.orcaslicer.com/latest` to `https://api.github.com/repos/Helio-Additive/OrcaSlicer/releases` so the app checks Helio's GitHub releases\n2. **`src/slic3r/GUI/GUI_App.cpp`**: Added parsing for `helio-v` tag prefix (e.g., `helio-v2.3.2` → `2.3.2`) so version comparison works with Helio's release tag format. The existing `v` prefix stripping is preserved as a fallback.\n3. **`src/slic3r/GUI/ReleaseNote.cpp`**: Updated dialog title from \"New version of Orca Slicer\" to \"New version of Helio OrcaSlicer\"\n4. **`src/slic3r/GUI/GUI_App.cpp`**: Updated force upgrade dialog title to \"Helio OrcaSlicer needs an upgrade\"\n\n## How it works\n\nThe existing `check_new_version_sf()` already parses GitHub-style release JSON (with `tag_name`, `prerelease`, `html_url`, `body` fields) and even sets the `application/vnd.github.v3+json` accept header. The only changes needed were:\n- Pointing to the correct API endpoint\n- Stripping the `helio-v` tag prefix for semver comparison\n- Updating user-visible strings\n\nThe \"Download\" button will now open the Helio release page, and release notes shown are from Helio's GitHub releases.\n\n## Tests\n\n- [ ] Verify version check popup appears with Helio release info\n- [ ] Verify \"Download\" opens Helio GitHub release page\n- [ ] Verify \"Skip this Version\" still works\n- [ ] Verify \"Check for stable updates only\" filters pre-releases correctly\n- [ ] Verify no popup when current version is latest\n\nhttps://claude.ai/code/session_01MR1jYBju7YwTqhneqUuzA5"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated product name shown in update dialogs to "Helio Orca Slicer".
  * Switched the app's default version-check source to use GitHub Releases.

* **Bug Fixes / Improvements**
  * Update checks now ignore draft releases and correctly recognize Helio-styled release tags (e.g., "helio-v1.2.3") for version matching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->