### PR TITLE
Fix dedupe-issues workflow: replace invalid claude_args with model input

### DIFF
--- a/.github/workflows/dedupe-issues.yml
+++ b/.github/workflows/dedupe-issues.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           prompt: "/dedupe ${{ github.repository }}/issues/${{ github.event.issue.number || inputs.issue_number }}"
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--model claude-sonnet-4-5-20250929"
+          model: "claude-sonnet-4-6"
           claude_env: |
             GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,13 @@ This is the Helio-Additive fork of OrcaSlicer. For Helio integration details, co
 - Auto-creates sync PRs with changelog and Helio-relevant change reports
 - Uses `claude-work` label to flag items for automated triage
 
+### Issue Dedupe (`dedupe-issues.yml`)
+- Triggers on new issue opened or manual `workflow_dispatch` with issue number
+- Uses `anthropics/claude-code-base-action@beta` with `/dedupe` slash command
+- Requires `CLAUDE_CODE_OAUTH_TOKEN` secret configured in repo settings
+- Model: `claude-sonnet-4-6`
+- Logs events to Statsig (optional, skips if `STATSIG_API_KEY` not set)
+
 ### Upstream Watch (`helio-upstream-watch.yml`)
 - Monitors upstream for new tags/releases and creates tracking issues
 


### PR DESCRIPTION
## Summary\n\n- Replace invalid `claude_args: \"--model claude-sonnet-4-5-20250929\"` with the correct `model: \"claude-sonnet-4-6\"` input for `anthropics/claude-code-base-action@beta`\n- Document the dedupe-issues workflow in CLAUDE.md (trigger conditions, required secrets, model config)\n\nThe `claude_args` parameter is not a valid input for the claude-code-base-action. This caused all dedupe workflow runs to fail (see [failed runs from 3/24 and 3/29](https://github.com/Helio-Additive/OrcaSlicer/actions/runs/23699177596)).\n\n**Note:** The workflow also requires a `CLAUDE_CODE_OAUTH_TOKEN` secret to be configured in repo settings.\n\n## Test plan\n\n- [ ] Verify dedupe-issues workflow runs successfully on next issue open or manual dispatch\n- [ ] Confirm `CLAUDE_CODE_OAUTH_TOKEN` secret is configured in repo settings\n\nhttps://claude.ai/code/session_01P5ZaGV36rKUyiwrgotPC8Q"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration for the issue deduplication automation to use the latest Claude model specification format.

* **Documentation**
  * Added documentation for the Issue Dedupe workflow, including event triggers, manual dispatch options, required repository secrets, and configuration details for automating duplicate issue detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->