### PR TITLE
Fix Assess not showing potential time savings

### DIFF
--- a/src/libslic3r/GCode/GCodeProcessor.cpp
+++ b/src/libslic3r/GCode/GCodeProcessor.cpp
@@ -310,6 +310,7 @@ void GCodeProcessor::TimeMachine::reset()
     g1_times_cache = std::vector<G1LinesCacheItem>();
     first_layer_time = 0.0f;
     prepare_time = 0.0f;
+    roles_time.fill(0.0f);
 }
 
 static void planner_forward_pass_kernel(const GCodeProcessor::TimeBlock& prev, GCodeProcessor::TimeBlock& curr)
@@ -427,6 +428,8 @@ void GCodeProcessor::TimeMachine::calculate_time(GCodeProcessorResult& result, P
         //BBS
         if (block.flags.prepare_stage)
             prepare_time += block_time;
+        if (!block.flags.prepare_stage)
+            roles_time[static_cast<size_t>(block.role)] += block_time;
 
         if (block.layer_id == 1)
             first_layer_time += block_time;
@@ -2631,6 +2634,19 @@ float GCodeProcessor::get_time(PrintEstimatedStatistics::ETimeMode mode) const
 float GCodeProcessor::get_prepare_time(PrintEstimatedStatistics::ETimeMode mode) const
 {
     return (mode < PrintEstimatedStatistics::ETimeMode::Count) ? m_time_processor.machines[static_cast<size_t>(mode)].prepare_time : 0.0f;
+}
+
+std::vector<std::pair<ExtrusionRole, float>> GCodeProcessor::get_roles_time(PrintEstimatedStatistics::ETimeMode mode) const
+{
+    std::vector<std::pair<ExtrusionRole, float>> ret;
+    if (mode < PrintEstimatedStatistics::ETimeMode::Count) {
+        for (size_t i = 0; i < m_time_processor.machines[static_cast<size_t>(mode)].roles_time.size(); ++i) {
+            float time = m_time_processor.machines[static_cast<size_t>(mode)].roles_time[i];
+            if (time > 0.0f)
+                ret.push_back({ static_cast<ExtrusionRole>(i), time });
+        }
+    }
+    return ret;
 }
 
 std::string GCodeProcessor::get_time_dhm(PrintEstimatedStatistics::ETimeMode mode) const
@@ -5863,6 +5879,7 @@ void GCodeProcessor::update_estimated_times_stats()
         data.time = get_time(mode);
         data.prepare_time = get_prepare_time(mode);
         data.custom_gcode_times = get_custom_gcode_times(mode, true);
+        data.roles_times = get_roles_time(mode);
     };
 
     update_mode(PrintEstimatedStatistics::ETimeMode::Normal);

--- a/src/libslic3r/GCode/GCodeProcessor.cpp
+++ b/src/libslic3r/GCode/GCodeProcessor.cpp
@@ -418,7 +418,8 @@ void GCodeProcessor::TimeMachine::calculate_time(GCodeProcessorResult& result, P
     const size_t n_blocks_process = blocks.size() - keep_last_n_blocks;
     for (size_t i = 0; i < n_blocks_process; ++i) {
         const TimeBlock& block = blocks[i];
-        float block_time = block.time();
+        const float motion_time = block.time();
+        float block_time = motion_time;
         if (i == 0)
             block_time += additional_time;
 
@@ -429,7 +430,7 @@ void GCodeProcessor::TimeMachine::calculate_time(GCodeProcessorResult& result, P
         if (block.flags.prepare_stage)
             prepare_time += block_time;
         if (!block.flags.prepare_stage)
-            roles_time[static_cast<size_t>(block.role)] += block_time;
+            roles_time[static_cast<size_t>(block.role)] += motion_time;
 
         if (block.layer_id == 1)
             first_layer_time += block_time;

--- a/src/libslic3r/GCode/GCodeProcessor.cpp
+++ b/src/libslic3r/GCode/GCodeProcessor.cpp
@@ -2636,7 +2636,7 @@ float GCodeProcessor::get_prepare_time(PrintEstimatedStatistics::ETimeMode mode)
     return (mode < PrintEstimatedStatistics::ETimeMode::Count) ? m_time_processor.machines[static_cast<size_t>(mode)].prepare_time : 0.0f;
 }
 
-std::vector<std::pair<ExtrusionRole, float>> GCodeProcessor::get_roles_time(PrintEstimatedStatistics::ETimeMode mode) const
+std::vector<std::pair<ExtrusionRole, float>> GCodeProcessor::get_roles_times(PrintEstimatedStatistics::ETimeMode mode) const
 {
     std::vector<std::pair<ExtrusionRole, float>> ret;
     if (mode < PrintEstimatedStatistics::ETimeMode::Count) {
@@ -5879,7 +5879,7 @@ void GCodeProcessor::update_estimated_times_stats()
         data.time = get_time(mode);
         data.prepare_time = get_prepare_time(mode);
         data.custom_gcode_times = get_custom_gcode_times(mode, true);
-        data.roles_times = get_roles_time(mode);
+        data.roles_times = get_roles_times(mode);
     };
 
     update_mode(PrintEstimatedStatistics::ETimeMode::Normal);

--- a/src/libslic3r/GCode/GCodeProcessor.hpp
+++ b/src/libslic3r/GCode/GCodeProcessor.hpp
@@ -895,7 +895,7 @@ class Print;
         float get_prepare_time(PrintEstimatedStatistics::ETimeMode mode) const;
         std::string get_time_dhm(PrintEstimatedStatistics::ETimeMode mode) const;
         std::vector<std::pair<CustomGCode::Type, std::pair<float, float>>> get_custom_gcode_times(PrintEstimatedStatistics::ETimeMode mode, bool include_remaining) const;
-        std::vector<std::pair<ExtrusionRole, float>> get_roles_time(PrintEstimatedStatistics::ETimeMode mode) const;
+        std::vector<std::pair<ExtrusionRole, float>> get_roles_times(PrintEstimatedStatistics::ETimeMode mode) const;
 
         float get_first_layer_time(PrintEstimatedStatistics::ETimeMode mode) const;
 

--- a/src/libslic3r/GCode/GCodeProcessor.hpp
+++ b/src/libslic3r/GCode/GCodeProcessor.hpp
@@ -57,12 +57,15 @@ class Print;
             float time;
             float prepare_time;
             std::vector<std::pair<CustomGCode::Type, std::pair<float, float>>> custom_gcode_times;
+            std::vector<std::pair<ExtrusionRole, float>> roles_times;
 
             void reset() {
                 time = 0.0f;
                 prepare_time = 0.0f;
                 custom_gcode_times.clear();
                 custom_gcode_times.shrink_to_fit();
+                roles_times.clear();
+                roles_times.shrink_to_fit();
             }
         };
 
@@ -541,6 +544,8 @@ class Print;
             std::vector<ActualSpeedMove> actual_speed_moves;
             //BBS: prepare stage time before print model, including start gcode time and mostly same with start gcode time
             float prepare_time;
+            // Per-role time accumulator (indexed by ExtrusionRole)
+            std::array<float, static_cast<size_t>(ExtrusionRole::erCount)> roles_time;
 
             void reset();
 
@@ -890,6 +895,7 @@ class Print;
         float get_prepare_time(PrintEstimatedStatistics::ETimeMode mode) const;
         std::string get_time_dhm(PrintEstimatedStatistics::ETimeMode mode) const;
         std::vector<std::pair<CustomGCode::Type, std::pair<float, float>>> get_custom_gcode_times(PrintEstimatedStatistics::ETimeMode mode, bool include_remaining) const;
+        std::vector<std::pair<ExtrusionRole, float>> get_roles_time(PrintEstimatedStatistics::ETimeMode mode) const;
 
         float get_first_layer_time(PrintEstimatedStatistics::ETimeMode mode) const;
 

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -17448,7 +17448,8 @@ void Plater::show_helio_simulation_summary()
         // Simulation — show HelioSimulationResultsDialog
         HelioSimulationResultsDialog dlg(nullptr,
             result->simulation_result,
-            result->original_print_time_seconds);
+            result->original_print_time_seconds,
+            result->roles_times);
         dlg.ShowModal();
     } else if (result->action == 1) {
         // Optimization — show HelioRatingDialog

--- a/src/slic3r/Utils/HelioDragon.cpp
+++ b/src/slic3r/Utils/HelioDragon.cpp
@@ -2059,18 +2059,20 @@ void HelioBackgroundProcess::create_simulation_step(HelioQuery::CreateGCodeResul
                         if (check_simulation_progress_res.is_finished) {
                             // Start loading preview in background immediately (don't wait for dialog)
                             int original_time_seconds = static_cast<int>(m_gcode_result->print_statistics.modes[0].time);
+                            auto roles_times = m_gcode_result->print_statistics.modes[0].roles_times;
                             std::string url = check_simulation_progress_res.url;
                             std::string filename = m_gcode_result->filename;
                             HelioQuery::SimulationResult sim_result = check_simulation_progress_res.simulationResult;
 
                             // Store simulation result to current plate for later access (e.g., "View Summary" button)
-                            GUI::wxGetApp().plater()->CallAfter([sim_result, original_time_seconds]() {
+                            GUI::wxGetApp().plater()->CallAfter([sim_result, original_time_seconds, roles_times]() {
                                 auto* plate = GUI::wxGetApp().plater()->get_partplate_list().get_curr_plate();
                                 if (plate) {
                                     HelioPlateResult helio_result;
                                     helio_result.action = 0;  // Simulation
                                     helio_result.simulation_result = sim_result;
                                     helio_result.original_print_time_seconds = original_time_seconds;
+                                    helio_result.roles_times = roles_times;
                                     helio_result.is_valid = true;
                                     plate->set_helio_result(helio_result);
                                 }
@@ -2083,9 +2085,8 @@ void HelioBackgroundProcess::create_simulation_step(HelioQuery::CreateGCodeResul
                                                                    simulated_gcode_path, filename,
                                                                    notification_manager, rating_data);
 
-                            // OrcaSlicer doesn't have roles_times in Mode; pass empty
-                            GUI::wxGetApp().plater()->CallAfter([sim_result, original_time_seconds]() {
-                                GUI::HelioSimulationResultsDialog results_dlg(nullptr, sim_result, original_time_seconds);
+                            GUI::wxGetApp().plater()->CallAfter([sim_result, original_time_seconds, roles_times]() {
+                                GUI::HelioSimulationResultsDialog results_dlg(nullptr, sim_result, original_time_seconds, roles_times);
                                 results_dlg.ShowModal();
                             });
                             break;

--- a/src/slic3r/Utils/HelioDragon.hpp
+++ b/src/slic3r/Utils/HelioDragon.hpp
@@ -430,6 +430,7 @@ struct HelioPlateResult {
     // Simulation data
     HelioQuery::SimulationResult simulation_result;
     int original_print_time_seconds{0};
+    std::vector<std::pair<ExtrusionRole, float>> roles_times;
 
     // Optimization data
     int optimized_print_time_seconds{0};
@@ -442,6 +443,7 @@ struct HelioPlateResult {
         action = -1;
         simulation_result = HelioQuery::SimulationResult();
         original_print_time_seconds = 0;
+        roles_times.clear();
         optimized_print_time_seconds = 0;
         quality_mean_improvement.clear();
         quality_std_improvement.clear();

--- a/src/slic3r/Utils/HelioDragon.hpp
+++ b/src/slic3r/Utils/HelioDragon.hpp
@@ -14,6 +14,7 @@
 #include <boost/thread.hpp>
 #include <wx/event.h>
 #include <chrono>
+#include <utility>
 
 #include "PrintHost.hpp"
 #include "libslic3r/PrintConfig.hpp"


### PR DESCRIPTION
## Summary\n\n- Add per-role time tracking (`roles_times`) to `GCodeProcessor::Mode`, matching BambuStudio's implementation\n- Pass `roles_times` through `HelioPlateResult` to `HelioSimulationResultsDialog`\n- Fixes the empty `m_roles_times` that caused time savings calculation to always yield 0\n\nThe \"Enhance Speed & Quality\" time savings block was never displayed because `roles_times` (time breakdown by extrusion role) was always passed as an empty vector. The speed improvement calculation iterates over `roles_times` to sum optimizable roles (perimeter, external perimeter, internal infill, solid infill) — with no data, improvement is always 0.\n\n**Changes:**\n1. `GCodeProcessor.hpp` — Added `roles_time` array to `TimeMachine`, `roles_times` to `Mode` struct\n2. `GCodeProcessor.cpp` — Accumulate per-role time in `calculate_time()`, added `get_roles_time()`, populate in `update_estimated_times_stats()`\n3. `HelioDragon.hpp/cpp` — Store and pass `roles_times` in `HelioPlateResult` and simulation callbacks\n4. `Plater.cpp` — Pass stored `roles_times` to dialog in \"View Summary\"\n\nFixes #50\n\n## Test plan\n\n- [ ] Slice an object, run Helio Assess simulation, verify time savings block appears in results\n- [ ] Verify \"View Summary\" button also shows time savings after simulation completes\n- [ ] Confirm existing optimization (action=1) flow is unaffected\n- [ ] Build on all platforms (Linux, macOS, Windows)\n\nhttps://claude.ai/code/session_01RygMwN8teqdqo2HNhDPjDF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Print time estimation now reports a per-extrusion-role time breakdown (walls, infill, supports, etc.) so users can see how total print time is distributed.
  * Helio simulation results, summary dialog, and saved plate results now display and store these per-role timing details alongside overall estimated print time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->