### PR TITLE
ci: fix silent no-op in helio-upstream-sync (prerelease tags ranked above stable)

### DIFF
--- a/.github/workflows/helio-upstream-sync.yml
+++ b/.github/workflows/helio-upstream-sync.yml
@@ -77,8 +77,12 @@ jobs:
             BRANCH_NAME="helio-upstream-main-$(date '+%Y-%m-%d')-${SHORT_SHA}"
             TRACKING_TAG="helio-last-synced-main"
           else
-            # Find latest upstream v* tag
-            LATEST_TAG=$(git tag -l 'v*' --sort=-version:refname | head -1)
+            # Find latest upstream stable v* tag (exclude alpha/beta/rc/pre/dev
+            # prereleases — git's version:refname sort otherwise ranks e.g.
+            # v2.3.2-rc2 above v2.3.2, causing stable releases to be missed)
+            LATEST_TAG=$(git tag -l 'v*' --sort=-version:refname \
+              | grep -Ev -- '-(alpha|beta|rc|pre|dev)([0-9]+)?$' \
+              | head -1)
             if [ -z "$LATEST_TAG" ]; then
               echo "No upstream release tags found"
               exit 1

--- a/.github/workflows/helio-upstream-sync.yml
+++ b/.github/workflows/helio-upstream-sync.yml
@@ -87,7 +87,7 @@ jobs:
               | grep -Evi -- '-(alpha|beta|rc|pre|dev)([.-]?[0-9A-Za-z]+)?$' \
               | head -1 || true)
             if [ -z "$LATEST_TAG" ]; then
-              echo "No upstream release tags found"
+              echo "No stable upstream release tags found" >&2
               exit 1
             fi
             SYNC_REF="$LATEST_TAG"

--- a/.github/workflows/helio-upstream-sync.yml
+++ b/.github/workflows/helio-upstream-sync.yml
@@ -79,10 +79,13 @@ jobs:
           else
             # Find latest upstream stable v* tag (exclude alpha/beta/rc/pre/dev
             # prereleases — git's version:refname sort otherwise ranks e.g.
-            # v2.3.2-rc2 above v2.3.2, causing stable releases to be missed)
+            # v2.3.2-rc2 above v2.3.2, causing stable releases to be missed).
+            # The regex tolerates both `-rc2`-style and dotted `-rc.1`-style
+            # SemVer suffixes. `|| true` keeps pipefail happy when grep finds
+            # nothing (only prereleases exist) — handled by the empty-check below.
             LATEST_TAG=$(git tag -l 'v*' --sort=-version:refname \
-              | grep -Ev -- '-(alpha|beta|rc|pre|dev)([0-9]+)?$' \
-              | head -1)
+              | grep -Evi -- '-(alpha|beta|rc|pre|dev)([.-]?[0-9A-Za-z]+)?$' \
+              | head -1 || true)
             if [ -z "$LATEST_TAG" ]; then
               echo "No upstream release tags found"
               exit 1

--- a/.github/workflows/helio-upstream-watch.yml
+++ b/.github/workflows/helio-upstream-watch.yml
@@ -55,8 +55,11 @@ jobs:
             NEW_TAGS="None"
           fi
 
-          # Commits on main since last release
-          LATEST_TAG=$(git tag -l 'v*' --sort=-version:refname | head -1)
+          # Commits on main since last release (exclude prereleases — git's
+          # version:refname sort ranks e.g. v2.3.2-rc2 above v2.3.2 otherwise)
+          LATEST_TAG=$(git tag -l 'v*' --sort=-version:refname \
+            | grep -Ev -- '-(alpha|beta|rc|pre|dev)([0-9]+)?$' \
+            | head -1)
           MAIN_COMMITS=$(git rev-list --count "$LATEST_TAG"..upstream/main 2>/dev/null || echo "unknown")
 
           # Active release branches

--- a/.github/workflows/helio-upstream-watch.yml
+++ b/.github/workflows/helio-upstream-watch.yml
@@ -56,10 +56,15 @@ jobs:
           fi
 
           # Commits on main since last release (exclude prereleases — git's
-          # version:refname sort ranks e.g. v2.3.2-rc2 above v2.3.2 otherwise)
+          # version:refname sort ranks e.g. v2.3.2-rc2 above v2.3.2 otherwise).
+          # `|| true` keeps pipefail happy when grep finds nothing.
           LATEST_TAG=$(git tag -l 'v*' --sort=-version:refname \
-            | grep -Ev -- '-(alpha|beta|rc|pre|dev)([0-9]+)?$' \
-            | head -1)
+            | grep -Evi -- '-(alpha|beta|rc|pre|dev)([.-]?[0-9A-Za-z]+)?$' \
+            | head -1 || true)
+          if [ -z "$LATEST_TAG" ]; then
+            echo "No stable upstream release tags found" >&2
+            exit 1
+          fi
           MAIN_COMMITS=$(git rev-list --count "$LATEST_TAG"..upstream/main 2>/dev/null || echo "unknown")
 
           # Active release branches


### PR DESCRIPTION
## Summary

The weekly `Helio Upstream Sync` workflow has been silently no-op'ing since v2.3.2-rc2 was synced. Upstream has since released `v2.3.2` stable, but no sync PR or conflict issue was ever produced for it.

**Root cause:** Git's `--sort=-version:refname` ranks prerelease-suffixed tags (e.g. `v2.3.2-rc2`) **above** their stable base (`v2.3.2`), so `head -1` in `helio-upstream-sync.yml:81` picks `v2.3.2-rc2`. Since `helio-last-synced` already points at that commit, the workflow's "already synced" guard matches and exits with `skip=true` — no PR, no issue, no watch comment. The same bad sort is in `helio-upstream-watch.yml:59`, making "commits on main since last release" count against `-rc2` instead of stable.

Verified locally:

```
$ git tag -l 'v*' --sort=-version:refname | head -5
v2.3.2-rc2      ← silently picked as "latest"
v2.3.2-rc
v2.3.2-beta2
v2.3.2-beta
v2.3.2          ← actual stable release
```

## Fix

Filter prerelease suffixes before taking the top tag in both workflows:

```bash
LATEST_TAG=$(git tag -l 'v*' --sort=-version:refname \
  | grep -Ev -- '-(alpha|beta|rc|pre|dev)([0-9]+)?$' \
  | head -1)
```

With the filter, the same pipe correctly returns `v2.3.2`.

## Test plan

- [ ] Merge this PR
- [ ] Manually dispatch **Helio Upstream Sync** with `sync_target=latest-tag`
  - Expect: `Sync target: v2.3.2 (v2.3.2 -> c724a3f5...)`, `skip=false`, branch `helio-release-candidate-v2.3.2` pushed
  - Given the `MainFrame.cpp` conflicts previously seen in #29/#30, expect the **conflict-issue** path (labeled `upstream-sync` + `claude-work`) rather than a clean-merge PR
- [ ] Manually dispatch **Helio Upstream Watch**
  - Expect: next digest comment on #21 references `v2.3.2` (not `-rc2`) as latest tag

## Follow-ups (not in this PR)

- Conflict issues #29 / #30 from 2026-03-23 were closed without a resolution PR merging — worth confirming whether those sessions got abandoned.
- The hardcoded fallback baseline `v2.3.2-rc2` at `helio-upstream-sync.yml:127` and `helio-upstream-watch.yml:43` will become stale once `helio-last-synced` advances past it — clean up after the first successful latest-tag sync.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated upstream synchronization and version detection workflows to filter and exclude prerelease versions, ensuring only stable releases are selected as the latest version reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->