### PR TITLE
Fix locale decimal delimiter breaking Helio API calls

### DIFF
--- a/src/libslic3r/LocalesUtils.cpp
+++ b/src/libslic3r/LocalesUtils.cpp
@@ -77,6 +77,7 @@ std::string float_to_string_decimal_point(double value, int precision/* = -1*/)
     return std::string(out, res.ptr - out);
 #else
     std::stringstream buf;
+    buf.imbue(std::locale::classic());
     if (precision >= 0)
         buf << std::fixed << std::setprecision(precision);
     buf << value;

--- a/src/libslic3r/LocalesUtils.cpp
+++ b/src/libslic3r/LocalesUtils.cpp
@@ -3,6 +3,7 @@
 #ifdef _WIN32
     #include <charconv>
 #endif
+#include <locale>
 #include <stdexcept>
 
 #include <fast_float/fast_float.h>

--- a/src/slic3r/Utils/HelioDragon.cpp
+++ b/src/slic3r/Utils/HelioDragon.cpp
@@ -604,7 +604,7 @@ void HelioQuery::optimization_feedback(const std::string helio_api_url, const st
 
     query_body = boost::str(boost::format(query_body)
         % optimization_id
-        % rating
+        % float_to_string_decimal_point(rating)
         % comment);
     auto http = Http::post(helio_api_url);
 
@@ -1213,15 +1213,15 @@ std::string HelioQuery::generate_simulation_graphql_query(const std::string &gco
     std::vector<std::string> settings_fields;
 
     if (temperatureStabilizationHeight != -1) {
-        settings_fields.push_back(boost::str(boost::format(R"(                    "temperatureStabilizationHeight": %1%)") % temperatureStabilizationHeight));
+        settings_fields.push_back(R"(                    "temperatureStabilizationHeight": )" + float_to_string_decimal_point(temperatureStabilizationHeight));
     }
 
     if (airTemperatureAboveBuildPlate != -1) {
-        settings_fields.push_back(boost::str(boost::format(R"(                    "airTemperatureAboveBuildPlate": %1%)") % airTemperatureAboveBuildPlate));
+        settings_fields.push_back(R"(                    "airTemperatureAboveBuildPlate": )" + float_to_string_decimal_point(airTemperatureAboveBuildPlate));
     }
 
     if (stabilizedAirTemperature != -1) {
-        settings_fields.push_back(boost::str(boost::format(R"(                    "stabilizedAirTemperature": %1%)") % stabilizedAirTemperature));
+        settings_fields.push_back(R"(                    "stabilizedAirTemperature": )" + float_to_string_decimal_point(stabilizedAirTemperature));
     }
 
     std::string settings_block;
@@ -1269,15 +1269,15 @@ std::string HelioQuery::generate_optimization_graphql_query(const std::string& g
     // Step 1.SimulationSettingsInput
     std::vector<std::string> simulation_fields;
     if (temperatureStabilizationHeight != -1) {
-        simulation_fields.push_back(boost::str(boost::format(R"("temperatureStabilizationHeight": %1%)") % temperatureStabilizationHeight));
+        simulation_fields.push_back(R"("temperatureStabilizationHeight": )" + float_to_string_decimal_point(temperatureStabilizationHeight));
     }
-    
+
     if (airTemperatureAboveBuildPlate != -1) {
-        simulation_fields.push_back(boost::str(boost::format(R"("airTemperatureAboveBuildPlate": %1%)") % airTemperatureAboveBuildPlate));
+        simulation_fields.push_back(R"("airTemperatureAboveBuildPlate": )" + float_to_string_decimal_point(airTemperatureAboveBuildPlate));
     }
 
     if (stabilizedAirTemperature != -1) {
-        simulation_fields.push_back(boost::str(boost::format(R"("stabilizedAirTemperature": %1%)") % stabilizedAirTemperature));
+        simulation_fields.push_back(R"("stabilizedAirTemperature": )" + float_to_string_decimal_point(stabilizedAirTemperature));
     }
 
     std::string simulation_block = boost::join(simulation_fields, ",\n");
@@ -1286,28 +1286,25 @@ std::string HelioQuery::generate_optimization_graphql_query(const std::string& g
     std::vector<std::string> optimization_fields;
 
     if (useOldMethod) {
-        // OLD METHOD: Use optimizeOuterwall boolean (fallback when API print priority options unavailable)
-        optimization_fields.push_back(boost::str(boost::format(R"("optimizeOuterwall": %1%)")
-            % (optimizeOuterwall ? "true" : "false")));
+        optimization_fields.push_back(std::string(R"("optimizeOuterwall": )") + (optimizeOuterwall ? "true" : "false"));
     } else if (!printPriority.empty()) {
-        // NEW METHOD: Use printPriority string
-        optimization_fields.push_back(boost::str(boost::format(R"("printPriority": "%1%")") % printPriority));
+        optimization_fields.push_back(R"("printPriority": ")" + printPriority + R"(")");
     }
 
     if (minVelocity != -1) {
-        optimization_fields.push_back(boost::str(boost::format(R"("minVelocity": %1%)") % minVelocity));
+        optimization_fields.push_back(R"("minVelocity": )" + float_to_string_decimal_point(minVelocity));
     }
 
     if (maxVelocity != -1) {
-        optimization_fields.push_back(boost::str(boost::format(R"("maxVelocity": %1%)") % maxVelocity));
+        optimization_fields.push_back(R"("maxVelocity": )" + float_to_string_decimal_point(maxVelocity));
     }
-    
+
     if (minExtruderFlowRate != -1) {
-        optimization_fields.push_back(boost::str(boost::format(R"("minExtruderFlowRate": %1%)") % minExtruderFlowRate));
+        optimization_fields.push_back(R"("minExtruderFlowRate": )" + float_to_string_decimal_point(minExtruderFlowRate));
     }
-    
+
     if (maxExtruderFlowRate != -1) {
-        optimization_fields.push_back(boost::str(boost::format(R"("maxExtruderFlowRate": %1%)") % maxExtruderFlowRate));
+        optimization_fields.push_back(R"("maxExtruderFlowRate": )" + float_to_string_decimal_point(maxExtruderFlowRate));
     }
     
     optimization_fields.push_back(R"("residualStrategySettings": {"strategy": "LINEAR"})");


### PR DESCRIPTION
## Summary

Fixes #64 — Multicolour jobs fail when the app locale uses commas as decimal separators (e.g. French).

**Root cause:** `boost::format` uses the C++ global locale for number formatting, not the C locale. `CNumericLocalesSetter` (RAII guard) only changes the C locale via `uselocale()` / `setlocale(LC_NUMERIC)`, so `boost::format` still produces commas (e.g. `"minVelocity": 0,003`) when the app language is French, German, etc. The Helio API then rejects the malformed JSON.

**Fix (2 files):**
- **`LocalesUtils.cpp`** — `float_to_string_decimal_point()` on non-Windows now imbues `std::locale::classic()` on its internal `stringstream`, guaranteeing period decimal separators regardless of the global C++ locale.
- **`HelioDragon.cpp`** — All `boost::format` calls that format float/double values into GraphQL JSON payloads now use `float_to_string_decimal_point()` instead of passing raw numeric types to `boost::format`. Affected functions:
  - `optimization_feedback()` — rating parameter
  - `generate_simulation_graphql_query()` — temperature parameters
  - `generate_optimization_graphql_query()` — temperature, velocity, and flow rate parameters

The existing `CNumericLocalesSetter` guards are preserved as defense-in-depth for any C-locale-dependent code paths.

## Test plan
- [ ] Set app language to French (or another locale with comma decimal separator)
- [ ] Load a multicolour project, slice, click Helio → Enhance
- [ ] Verify optimization completes without value errors
- [ ] Repeat with Helio defaults and slicer defaults
- [ ] Verify single-material Helio simulation also works under French locale

---
_Generated by [Claude Code](https://claude.ai/code/session_016MiSRVPAqxy3BbzWmoMMF9)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed decimal-separator handling so numeric formatting is consistent across platforms.
  * Improved formatting of floating-point values in JSON/GraphQL payloads to prevent locale-related mismatches.
  * Updated assembly of several numeric fields to ensure stable, predictable serialization in communications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Helio-Additive/OrcaSlicer/pull/65?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a locale-sensitive decimal formatting bug where `boost::format` uses the C++ global locale (not the C locale managed by `CNumericLocalesSetter`), causing commas to appear as decimal separators in Helio API JSON payloads for users running non-English locales (e.g. French, German).

- **`LocalesUtils.cpp`**: The non-Windows `float_to_string_decimal_point()` path now imbues `std::locale::classic()` on its `stringstream`, making the output locale-independent regardless of the global C++ locale. The Windows path was already safe (`std::to_chars` ignores locale).
- **`HelioDragon.cpp`**: Every `boost::format` call that previously passed a raw `float`/`double` into a GraphQL JSON payload now goes through `float_to_string_decimal_point()`. Integer fields and string fields that remain in `boost::format` calls are correctly excluded.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is narrowly scoped to locale-sensitive number formatting, and all float/double API values are now correctly handled through the locale-independent helper.

The root cause is correctly identified and fixed in the minimal possible way. No remaining boost::format calls pass float/double values to JSON payloads, and no pre-existing safety guards were removed.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/libslic3r/LocalesUtils.cpp | Adds `buf.imbue(std::locale::classic())` to the non-Windows `stringstream` path in `float_to_string_decimal_point()` — minimal, targeted fix that closes the root cause of locale-sensitive decimal formatting. |
| src/slic3r/Utils/HelioDragon.cpp | All float/double values passed to Helio GraphQL API payloads are now routed through `float_to_string_decimal_point()`; integer and string-typed fields are left unchanged, which is correct. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Float/double value] --> B{Platform}
    B -- Windows --> C["std::to_chars() locale-independent"]
    B -- non-Windows/Before --> F["stringstream uses global C++ locale"]
    F --> G["Comma separator in French locale"]
    G --> H["Malformed JSON - API rejects payload"]
    B -- non-Windows/After --> I["buf.imbue(std::locale::classic())"]
    I --> J["Period separator e.g. 25.5"]
    C --> J
    J --> K["Valid JSON sent to Helio API"]
```

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;orca-latest-parity-bambu&#39; ..."](https://github.com/helio-additive/orcaslicer/commit/4d25519f4ad36a7c3391919c30f7f7859464892f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32925586)</sub>

<!-- /greptile_comment -->