### PR TITLE
Fix upstream sync: handle squash merges and protected branch deletion

### DIFF
--- a/.github/workflows/helio-upstream-sync.yml
+++ b/.github/workflows/helio-upstream-sync.yml
@@ -162,6 +162,22 @@ jobs:
             exit 0
           fi
 
+          # Handle squash merges: the ancestor check above fails when a PR was
+          # squash-merged because the original upstream commit is not in the
+          # history.  Try a trial merge — if it succeeds with no diff, the
+          # content is already incorporated.
+          if git merge --no-commit --no-ff "$SYNC_SHA" 2>/dev/null; then
+            if git diff --cached --quiet 2>/dev/null; then
+              echo "Target $SYNC_LABEL already incorporated (squash merge detected) — updating tracking tag and skipping"
+              git merge --abort 2>/dev/null || git reset --hard HEAD
+              git tag -f "$TRACKING_TAG" "$SYNC_SHA"
+              git push origin "$TRACKING_TAG" --force
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          fi
+          git merge --abort 2>/dev/null || git reset --hard HEAD 2>/dev/null || true
+
           echo "last_synced=$LAST_SYNCED" >> "$GITHUB_OUTPUT"
           echo "skip=false" >> "$GITHUB_OUTPUT"
 
@@ -293,10 +309,13 @@ jobs:
               echo "::warning::Remote branch '$BRANCH' has commits beyond our base — someone may be resolving conflicts. Skipping to avoid losing work."
               exit 0
             fi
-            # Remote is at a stale commit from a previous run — safe to replace.
-            git push origin --delete "$BRANCH"
+            # Remote is at a stale commit from a previous run — force-push to
+            # replace it.  Using --force avoids the need to delete the branch
+            # first, which fails when branch protection rules block deletion.
+            git push origin "$BRANCH" --force
+          else
+            git push origin "$BRANCH"
           fi
-          git push origin "$BRANCH"
 
       - name: Handle merge conflicts
         if: steps.check.outputs.skip != 'true' && steps.merge.outputs.status == 'conflict'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,8 @@ This is the Helio-Additive fork of OrcaSlicer. For Helio integration details, co
 - Auto-creates sync PRs with changelog and Helio-relevant change reports
 - Uses `claude-work` label to flag items for automated triage
 - Detects out-of-band merges (e.g. manual PRs) via ancestor check and auto-updates the tracking tag
-- Handles pre-existing conflict branches safely: checks for divergence before replacing (skips if someone has pushed resolution commits, replaces only stale branches from previous runs)
+- Handles pre-existing conflict branches safely: checks for divergence before replacing (skips if someone has pushed resolution commits, force-pushes to replace stale branches from previous runs)
+- Detects squash merges: when the ancestor check fails, tries a trial merge to detect if content is already incorporated
 
 ### Issue Dedupe (`dedupe-issues.yml`)
 - Triggers on new issue opened or manual `workflow_dispatch` with issue number


### PR DESCRIPTION
## Summary

Fixes the recurring `Helio Upstream Sync` workflow failure ([run 27132271079](https://github.com/Helio-Additive/OrcaSlicer/actions/runs/27132271079)).

**Root cause (two issues):**

1. **Squash merge detection**: v2.3.2 was squash-merged via PRs #60 and #67, so the original upstream commit (`c724a3f5`) is not an ancestor of HEAD. The workflow's `git merge-base --is-ancestor` check always returns false, causing it to re-attempt the sync on every run.

2. **Protected branch deletion**: PR #68 changed the conflict branch push from `--force-with-lease` to delete+push, but repository rules block branch deletion (`GH013: Cannot delete this branch`), causing the push step to fail.

**Fixes:**

- **Squash-merge detection**: After the ancestor check fails, tries a trial `git merge --no-commit` — if the merge succeeds with an empty diff, the content is already incorporated. Updates the tracking tag and skips.
- **Force-push for stale branches**: Replaces delete+push with `--force` when the remote branch is stale, avoiding the branch deletion restriction entirely.

## Test plan
- [ ] Trigger the workflow manually (`workflow_dispatch`) — should detect v2.3.2 is already incorporated via the trial merge, update the tracking tag, and exit cleanly
- [ ] Verify the `helio-last-synced` tag points to the v2.3.2 commit after the run
- [ ] Wait for next scheduled Monday run to confirm no more failures
- [ ] Verify that a genuine new upstream tag (e.g. v2.4.0) still triggers a real sync

---
_Generated by [Claude Code](https://claude.ai/code/session_01RgDDaaFqZ3CLnAQUHtBN4c)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved upstream synchronization workflow to better handle squash merges and resolve conflicts more reliably, even with branch protection rules enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->