### PR TITLE
Fix "Bambu Lab" branding in Special Note & Privacy (#79)

### DIFF
--- a/resources/web/helio/helio_service_snote_cn.html
+++ b/resources/web/helio/helio_service_snote_cn.html
@@ -161,7 +161,7 @@
 <body>
     <p><span class="special-note">特别说明</span></p>
 
-    <p>该内容由第三方 Helio Additive 提供和托管。所有数据收集和处理活动均由 Helio Additive 独立负责，Bambu Lab对此不承担任何责任。 点击“同意并继续”即表示您同意 <a class="underline" href="#" onclick="OpenPPLink()">Helio Additive的隐私协议</a>。</p>
+    <p>该内容由第三方 Helio Additive 提供和托管。所有数据收集和处理活动均由 Helio Additive 独立负责，Orca Slicer对此不承担任何责任。 点击“同意并继续”即表示您同意 <a class="underline" href="#" onclick="OpenPPLink()">Helio Additive的隐私协议</a>。</p>
 
 </body>
 </html>

--- a/resources/web/helio/helio_service_snote_en.html
+++ b/resources/web/helio/helio_service_snote_en.html
@@ -142,7 +142,7 @@
 <body>
     <p><span class="special-note">Special Note</span></p>
     
-    <p>This service is provided and hosted by a third party, Helio Additive. All data collection and processing activities are solely managed by Helio Additive, and Bambu Lab assumes no responsibility in this regard.  By clicking "Accept and proceed", you agree to <a class="underline" href="#" onclick="OpenPPLink()">Helio Additive's privacy policy. </a></p>
+    <p>This service is provided and hosted by a third party, Helio Additive. All data collection and processing activities are solely managed by Helio Additive, and Orca Slicer assumes no responsibility in this regard.  By clicking "Accept and proceed", you agree to <a class="underline" href="#" onclick="OpenPPLink()">Helio Additive's privacy policy. </a></p>
 	
 </body>
 </html>

--- a/src/slic3r/GUI/HelioReleaseNote.cpp
+++ b/src/slic3r/GUI/HelioReleaseNote.cpp
@@ -502,7 +502,7 @@ void HelioStatementDialog::create_legal_page()
     wxBoxSizer* privacy_content_sizer = new wxBoxSizer(wxVERTICAL);
     
     auto privacy_text = new Label(privacy_content_panel, Label::Body_12, 
-        _L("This service is provided and hosted by a third party, Helio Additive. All data collection and processing activities are solely managed by Helio Additive, and Bambu Lab assumes no responsibility in this regard. By clicking \"Agree and Proceed\", you agree to Helio Additive's privacy policy."));
+        _L("This service is provided and hosted by a third party, Helio Additive. All data collection and processing activities are solely managed by Helio Additive, and Orca Slicer assumes no responsibility in this regard. By clicking \"Agree and Proceed\", you agree to Helio Additive's privacy policy."));
     privacy_text->SetForegroundColour(wxColour(200, 200, 200));
     privacy_text->SetMinSize(wxSize(FromDIP(560), -1));
     privacy_text->Wrap(FromDIP(560));


### PR DESCRIPTION
## Summary

Fixes #79 — Changes "Bambu Lab assumes no responsibility" to "Orca Slicer assumes no responsibility" in the Special Note & Privacy section of the Helio integration dialog.

- **`HelioReleaseNote.cpp`** — Updated the C++ dialog text in `create_legal_page()`
- **`helio_service_snote_en.html`** — Updated the English HTML variant
- **`helio_service_snote_cn.html`** — Updated the Chinese HTML variant

## Test plan
- [ ] Click third-party icon → Enable Helio Additive → Scroll to Special Note & Privacy
- [ ] Verify 2nd sentence reads "Orca Slicer assumes no responsibility" (not "Bambu Lab")
- [ ] Check both English and Chinese locale versions

https://claude.ai/code/session_01LfSbVfQ7ZZUBAzyM62hb2S

---
_Generated by [Claude Code](https://claude.ai/code/session_01LfSbVfQ7ZZUBAzyM62hb2S)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated privacy policy and disclaimer text in user interface dialogs across multiple language versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->