### PR TITLE
Fix upstream sync issue body exceeding 65536 char limit

### DIFF
--- a/.github/workflows/helio-upstream-sync.yml
+++ b/.github/workflows/helio-upstream-sync.yml
@@ -341,14 +341,27 @@ jobs:
               return;
             }
 
-            const body = [
+            // Truncate conflict list if it would push the body over
+            // GitHub's 65 536-character issue-body limit.
+            const conflictLines = (conflicts || '').split('\n');
+            const MAX_BODY = 65000; // leave headroom for encoding overhead
+            const MAX_CONFLICT_LINES = 200;
+            let conflictBlock;
+            if (conflictLines.length > MAX_CONFLICT_LINES) {
+              conflictBlock = conflictLines.slice(0, MAX_CONFLICT_LINES).join('\n')
+                + `\n... and ${conflictLines.length - MAX_CONFLICT_LINES} more files (${conflictLines.length} total)`;
+            } else {
+              conflictBlock = conflicts;
+            }
+
+            let body = [
               `## Merge conflicts detected syncing ${syncLabel}`,
               '',
-              `The automatic merge of upstream \`${syncLabel}\` into \`${target}\` produced conflicts.`,
+              `The automatic merge of upstream \`${syncLabel}\` into \`${target}\` produced conflicts in **${conflictLines.length} files**.`,
               '',
               '### Conflicted files',
               '```',
-              conflicts,
+              conflictBlock,
               '```',
               '',
               '### Helio-relevant upstream changes',
@@ -369,6 +382,12 @@ jobs:
               '',
               'See `HELIO_INTEGRATION.md` for detailed conflict resolution rules.',
             ].join('\n');
+
+            // Final safety: hard-truncate if still over the limit
+            if (body.length > MAX_BODY) {
+              body = body.slice(0, MAX_BODY)
+                + '\n\n---\n*Issue body truncated — full conflict list available via `git diff --name-only --diff-filter=U`*';
+            }
 
             // Ensure required labels exist before creating the issue; a missing
             // label causes a 422 validation error that would suppress the issue.

--- a/.github/workflows/helio-upstream-sync.yml
+++ b/.github/workflows/helio-upstream-sync.yml
@@ -385,8 +385,9 @@ jobs:
 
             // Final safety: hard-truncate if still over the limit
             if (body.length > MAX_BODY) {
-              body = body.slice(0, MAX_BODY)
-                + '\n\n---\n*Issue body truncated — full conflict list available via `git diff --name-only --diff-filter=U`*';
+              const truncationNote = '\n\n---\n*Issue body truncated — full conflict list available via `git diff --name-only --diff-filter=U`*';
+              const sliceLimit = Math.max(0, MAX_BODY - truncationNote.length);
+              body = body.slice(0, sliceLimit) + truncationNote;
             }
 
             // Ensure required labels exist before creating the issue; a missing


### PR DESCRIPTION
## Summary

Fixes the Helio Upstream Sync workflow failing when the auto-created merge conflict issue body exceeds GitHub's 65,536 character limit.

**Root cause:** When syncing large upstream releases (e.g. v2.4.0 with hundreds of conflicted files), the workflow embeds every conflicted filename in the issue body. For v2.4.0, this produced a body >65K chars, causing a `422 Validation Failed` error and preventing the conflict issue from being created.

**Fix:**
- Truncate the conflict file list to the first 200 lines when the list is long, with a count of remaining files
- Add a hard safety cap on total body length (65,000 chars) with a note pointing to the `git diff` command for the full list
- Show total conflict count in the issue description for visibility

**Triggered by:** Failed run [#27948157632](https://github.com/Helio-Additive/OrcaSlicer/actions/runs/27948157632) on June 22, 2026.

## Test plan
- [ ] Re-run the upstream sync workflow manually — it should now create the v2.4.0 conflict issue successfully
- [ ] Verify the truncated issue body is readable and includes the conflict count

---
_Generated by [Claude Code](https://claude.ai/code/session_012qNu95eZXiao1QDApsnxG9)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved merge-conflict issue generation in automated workflows by truncating overly long conflicted-file lists to comply with platform limits.
  * Added an additional safety cap to ensure issue creation never fails due to excessive content size, while still indicating that the full list can be retrieved when needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->