### PR TITLE
Strip nozzle diameter from printer name for Helio matching

### DIFF
--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -9708,6 +9708,16 @@ static std::vector<HelioQuery::SupportedData> find_similar_printers(
     return similar_printers;
 }
 
+static std::string strip_nozzle_suffix(const std::string& preset_name, const Preset& preset)
+{
+    auto *printer_model_opt = preset.config.opt<ConfigOptionString>("printer_model");
+    if (printer_model_opt && !printer_model_opt->value.empty())
+        return printer_model_opt->value;
+
+    static const std::regex nozzle_re(R"(\s+\d+\.?\d*\s+[Nn]ozzle\s*$)");
+    return std::regex_replace(preset_name, nozzle_re, "");
+}
+
 static std::pair<std::string, size_t> match_printer_with_boundaries(
     const std::string& target_name,
     const std::vector<HelioQuery::SupportedData>& supported_printers)
@@ -10451,8 +10461,9 @@ int Plater::priv::update_helio_background_process_v2(std::string& printer_id, st
     BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << ": preset_name = '" << preset_name << "'";
     BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << ": global_supported_printers.size() = " << HelioQuery::global_supported_printers.size();
 
-    std::string printer_target_name = preset_name;
+    std::string printer_target_name = strip_nozzle_suffix(preset_name, preset_bundle->printers.get_edited_preset());
     boost::trim(printer_target_name);
+    BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << ": printer_target_name (nozzle stripped) = '" << printer_target_name << "'";
 
     if (printer_target_name.empty()) {
         GUI::MessageDialog msgdialog(nullptr, _L("Invalid printer preset. Unable to slice with Helio."), "", wxICON_WARNING | wxOK);
@@ -10797,8 +10808,9 @@ int Plater::priv::update_helio_background_process(std::string& printer_id,
 
     BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << ": preset_name = '" << preset_name << "'";
 
-    std::string printer_target_name = preset_name;
+    std::string printer_target_name = strip_nozzle_suffix(preset_name, preset_bundle->printers.get_edited_preset());
     boost::trim(printer_target_name);
+    BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << ": printer_target_name (nozzle stripped) = '" << printer_target_name << "'";
 
     if (printer_target_name.empty()) {
         GUI::MessageDialog msgdialog(nullptr, _L("Invalid printer preset. Unable to slice with Helio."), "", wxICON_WARNING | wxOK);


### PR DESCRIPTION
## Summary

Fixes #83 — OrcaSlicer appends the nozzle diameter to printer preset names (e.g. `Anycubic Kobra S1 Max 0.4 nozzle`), which produces different name strings for the same physical printer when the nozzle variant changes. This breaks Helio's matching, which relies on the printer name as a stable identifier.

**Fix:**
- Use the `printer_model` config field (e.g. `Anycubic Kobra S1 Max`) as the Helio matching target instead of the full preset name
- Fall back to regex stripping of the nozzle suffix (`\s+\d+\.?\d*\s+[Nn]ozzle\s*$`) for custom presets without a `printer_model` value
- Applied to both V2 (single material) and V3 (multi-material) code paths in `Plater.cpp`

This matches BambuStudio's approach, which uses `get_printer_name()` → `vendor_model.name` to get the base model name without nozzle info.

## Test plan
- [ ] Select a printer with multiple nozzle variants (e.g. Anycubic Kobra S1 with 0.4 and 0.6 nozzles)
- [ ] Verify Helio recognizes and matches both nozzle variants to the same printer
- [ ] Verify custom printer presets still match or fall back to reference printer selection
- [ ] Check logs for `printer_target_name (nozzle stripped)` confirming the clean name is used

---
_Generated by [Claude Code](https://claude.ai/code/session_01ULpMktt4a4tC97maFy4D8Y)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved printer/preset name handling by automatically removing nozzle-related suffixes from target names.
  * Preserves the configured printer model name when available, helping ensure the correct printer is selected.
  * Keeps the same warning behavior when a printer name is still missing after normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->