### PR TITLE
Fix false "Unsupported Materials" error on second instance

### DIFF
--- a/src/slic3r/CMakeLists.txt
+++ b/src/slic3r/CMakeLists.txt
@@ -656,6 +656,10 @@ set(SLIC3R_GUI_SOURCES
     Utils/PresetUpdater.hpp
     Utils/HelioDragon.cpp
     Utils/HelioDragon.hpp
+    Utils/HelioRetryPolicy.cpp
+    Utils/HelioRetryPolicy.hpp
+    Utils/HelioSupportData.cpp
+    Utils/HelioSupportData.hpp
     Utils/PrintHost.cpp
     Utils/PrintHost.hpp
     Utils/Process.cpp

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -2540,6 +2540,7 @@ int GUI_App::OnExit()
 {
     stop_http_server();
     stop_sync_user_preset();
+    Slic3r::HelioQuery::shutdown_background_requests();
 
     if (m_device_manager) {
         delete m_device_manager;

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -8809,13 +8809,18 @@ void GUI_App::request_helio_pat(std::function<void(std::string)> func)
     Slic3r::HelioQuery::request_pat_token(func);
 }
 
-void GUI_App::request_helio_supported_data()
+void GUI_App::request_helio_supported_data(bool force_refresh)
 {
     std::string helio_api_url = Slic3r::HelioQuery::get_helio_api_url();
     std::string helio_api_key = Slic3r::HelioQuery::get_helio_pat();
 
-    Slic3r::HelioQuery::request_all_support_machine(helio_api_url, helio_api_key);
-    Slic3r::HelioQuery::request_all_support_materials(helio_api_url, helio_api_key);
+    const bool printers_started =
+        Slic3r::HelioQuery::request_all_support_machine(helio_api_url, helio_api_key, force_refresh);
+    const bool materials_started =
+        Slic3r::HelioQuery::request_all_support_materials(helio_api_url, helio_api_key, force_refresh);
+    if (printers_started || materials_started) {
+        Slic3r::HelioQuery::clear_print_priority_cache();
+    }
 }
 
 void GUI_App::remove_mall_system_dialog()

--- a/src/slic3r/GUI/GUI_App.hpp
+++ b/src/slic3r/GUI/GUI_App.hpp
@@ -676,7 +676,7 @@ public:
     // Helio cloud processing
     bool            is_helio_enable();
     static void     request_helio_pat(std::function<void(std::string)> func);
-    static void     request_helio_supported_data();
+    static void     request_helio_supported_data(bool force_refresh = false);
 
     // Parameters extracted from the command line to be passed to GUI after initialization.
     GUI_InitParams* init_params { nullptr };

--- a/src/slic3r/GUI/HelioReleaseNote.cpp
+++ b/src/slic3r/GUI/HelioReleaseNote.cpp
@@ -1697,13 +1697,16 @@ void HelioInputDialog::update_mode_card_styling(int selected_action)
     // Determine heated_chamber from Helio API (default: false)
     bool has_heated_chamber = false;
     if (!printer_name.empty()) {
-        std::string target_lower = boost::to_lower_copy(printer_name);
-        for (const auto& p : HelioQuery::global_supported_printers) {
-            if (p.native_name.empty()) continue;
-            std::string native_lower = boost::to_lower_copy(p.native_name);
-            if (target_lower == native_lower || target_lower.find(native_lower) != std::string::npos) {
-                has_heated_chamber = p.heated_chamber;
-                break;
+        const auto supported_printers = HelioQuery::supported_printers_snapshot();
+        if (supported_printers) {
+            std::string target_lower = boost::to_lower_copy(printer_name);
+            for (const auto& p : *supported_printers) {
+                if (p.native_name.empty()) continue;
+                std::string native_lower = boost::to_lower_copy(p.native_name);
+                if (target_lower == native_lower || target_lower.find(native_lower) != std::string::npos) {
+                    has_heated_chamber = p.heated_chamber;
+                    break;
+                }
             }
         }
     }

--- a/src/slic3r/GUI/HelioReleaseNote.cpp
+++ b/src/slic3r/GUI/HelioReleaseNote.cpp
@@ -1033,8 +1033,7 @@ void HelioStatementDialog::request_pat()
                         copy_pat_button->Show();
                     }
 
-                    /*request helio data*/
-                    wxGetApp().request_helio_supported_data();
+                    // set_helio_pat triggers force-refresh automatically
                 }
             }
         });

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -10783,12 +10783,15 @@ private:
         // Store a copy for the background thread callback
         m_unsupported_copy = unsupported_filaments;
 
-        // Kick off the refresh from the main thread (safe wxWidgets access)
+        // Kick off the refresh from the main thread (safe wxWidgets access).
+        // Materials only: both the V2 and V3 callers resolve printer_id *before* opening
+        // this dialog and never revisit it, so refreshing the printer catalog here could
+        // leave them submitting an ID that the new snapshot no longer matches. This
+        // dialog is scoped to unsupported materials, and it is only reachable when both
+        // catalogs are already usable, so the printer snapshot needs no repair here.
         std::string url = HelioQuery::get_helio_api_url();
         std::string key = HelioQuery::get_helio_pat();
-        bool printers_started  = HelioQuery::request_all_support_machine(url, key, true);
-        bool materials_started = HelioQuery::request_all_support_materials(url, key, true);
-        if (printers_started || materials_started) {
+        if (HelioQuery::request_all_support_materials(url, key, true)) {
             HelioQuery::clear_print_priority_cache();
         }
 
@@ -10842,8 +10845,9 @@ private:
         // A failed refresh keeps the previous snapshot, so availability can still be
         // Usable here. Report that as a refresh failure rather than re-checking the
         // unchanged catalog and telling the user the materials are still unsupported.
-        if (HelioQuery::supported_materials_state() == SupportDataLoadState::Failed ||
-            HelioQuery::supported_printers_state() == SupportDataLoadState::Failed) {
+        // Only the materials store is refreshed by this dialog, so a pre-existing
+        // printer-store failure must not be reported as this refresh failing.
+        if (HelioQuery::supported_materials_state() == SupportDataLoadState::Failed) {
             m_refresh_status->SetLabel(_L("Refresh failed. Please try again later."));
             m_refresh_button->Enable(true);
             Layout();

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -10795,13 +10795,17 @@ private:
         m_dialog_alive = std::make_shared<std::atomic<bool>>(true);
         auto alive = m_dialog_alive;
 
-        // Wait for stores to finish loading in a background thread
+        // Wait for stores to finish loading in a background thread.
+        // Also wait while a pending refresh exists — a force-refresh queued behind an
+        // in-flight load briefly leaves the Loading state before the worker picks up
+        // the pending flag and re-enters Loading.
         m_refresh_thread = std::make_unique<std::thread>([this, alive]() {
             constexpr int timeout_ms = 60000;
             int elapsed = 0;
             while (*alive && elapsed < timeout_ms &&
                    (HelioQuery::supported_materials_state() == SupportDataLoadState::Loading ||
-                    HelioQuery::supported_printers_state() == SupportDataLoadState::Loading)) {
+                    HelioQuery::supported_printers_state() == SupportDataLoadState::Loading ||
+                    HelioQuery::has_pending_support_data_refresh())) {
                 std::this_thread::sleep_for(std::chrono::milliseconds(100));
                 elapsed += 100;
             }
@@ -17800,7 +17804,7 @@ void Plater::set_helio_elements_have_been_loaded(bool status)
 
 std::optional<std::string> Plater::get_helio_material_id_for_the_current_selection(size_t extruder_id)
 {
-    if (HelioQuery::supported_materials_state() != SupportDataLoadState::Ready)
+    if (HelioQuery::supported_data_availability() != SupportDataAvailability::Usable)
         return std::nullopt;
 
     // Get current filament preset name for the given extruder

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -10800,7 +10800,14 @@ private:
         // in-flight load briefly leaves the Loading state before the worker picks up
         // the pending flag and re-enters Loading.
         m_refresh_thread = std::make_unique<std::thread>([this, alive]() {
-            constexpr int timeout_ms = 60000;
+            // The deadline has to cover the store's whole request budget, not a single
+            // request: helio_fetch_support_data_page() allows 100s per attempt and the
+            // store permits MAX_ATTEMPTS_PER_PAGE attempts plus backoff waits between
+            // them. At 60s this loop exited while a catalog was still Loading, so
+            // on_refresh_complete() reported failure (or re-checked the stale snapshot)
+            // while the original fetch was still running, and re-enabling the button let
+            // repeated clicks queue redundant loads.
+            constexpr int timeout_ms = 480000;
             int elapsed = 0;
             while (*alive && elapsed < timeout_ms &&
                    (HelioQuery::supported_materials_state() == SupportDataLoadState::Loading ||
@@ -10820,7 +10827,17 @@ private:
     }
 
     void on_refresh_complete() {
-        if (HelioQuery::supported_data_availability() == SupportDataAvailability::Usable) {
+        const SupportDataAvailability availability = HelioQuery::supported_data_availability();
+        if (availability == SupportDataAvailability::Synchronizing) {
+            // The deadline elapsed with a load still in flight — don't call that a
+            // failure, the fetch may still succeed.
+            m_refresh_status->SetLabel(_L("Still synchronizing supported materials. Please try again in a moment."));
+            m_refresh_button->Enable(true);
+            Layout();
+            Fit();
+            return;
+        }
+        if (availability == SupportDataAvailability::Usable) {
             // Re-check all unsupported filaments
             bool all_now_supported = true;
             for (const auto& info : m_unsupported_copy) {
@@ -11232,7 +11249,10 @@ int Plater::priv::update_helio_background_process(std::string& printer_id,
     }
 
     const auto supported_printers = HelioQuery::supported_printers_snapshot();
-    const auto supported_materials = HelioQuery::supported_materials_snapshot();
+    // Not const: an in-dialog "Refresh & Retry" can publish a newer catalog partway
+    // through the per-slot loop below, and the remaining slots must be matched against
+    // that newer snapshot rather than the one captured here.
+    auto supported_materials = HelioQuery::supported_materials_snapshot();
     if (HelioQuery::supported_data_availability() != SupportDataAvailability::Usable ||
         !supported_printers || !supported_materials) {
         BOOST_LOG_TRIVIAL(error) << __FUNCTION__ << ": Helio support-data snapshot is unavailable";
@@ -11447,7 +11467,14 @@ int Plater::priv::update_helio_background_process(std::string& printer_id,
                 materials[i].materialId = unsupported_dialog.get_selected_material_id();
                 helio_using_reference_material = true;
             } else if (choice == 3) {
-                // Refresh succeeded — re-check this filament
+                // Refresh succeeded — adopt the newly published catalog for the
+                // remaining slots too, otherwise they would keep being matched against
+                // the snapshot captured before the refresh and a now-supported material
+                // could still be rejected.
+                if (auto refreshed_materials = HelioQuery::supported_materials_snapshot()) {
+                    supported_materials = std::move(refreshed_materials);
+                }
+                // Re-check this filament
                 FilamentSupportInfo recheck = check_filament_helio_support(used_filament, (int)i);
                 if (recheck.is_supported && !recheck.material_id.empty()) {
                     materials[i].materialId = recheck.material_id;

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -9967,8 +9967,11 @@ static FilamentSupportInfo check_filament_helio_support(const std::string& filam
     boost::trim(target_name);
 
     const auto supported_materials = HelioQuery::supported_materials_snapshot();
-    if (!supported_materials)
+    if (!supported_materials) {
+        BOOST_LOG_TRIVIAL(warning) << "check_filament_helio_support: snapshot is null for '"
+                                   << filament_preset_name << "'";
         return info;
+    }
 
     size_t best_match_length = 0;
     for (const HelioQuery::SupportedData& pdata : *supported_materials) {
@@ -10005,6 +10008,13 @@ static FilamentSupportInfo check_filament_helio_support(const std::string& filam
             info.is_supported = true;
         }
     }
+
+    if (!info.is_supported) {
+        BOOST_LOG_TRIVIAL(warning) << "check_filament_helio_support: no match for '"
+                                   << target_name << "' (preset: '" << filament_preset_name
+                                   << "') among " << supported_materials->size() << " materials";
+    }
+
     return info;
 }
 
@@ -11625,9 +11635,8 @@ void Plater::priv::on_action_helio_processing(SimpleEvent& a)
 {
     if (!(partplate_list.get_curr_plate()->empty())) {
         helio_processing_disabled = true;
-        auto    app_config    = wxGetApp().app_config;
-        std::string helio_api_key = app_config->get("helio_access_token");
-        std::string helio_api_url = app_config->get("helio_api_url");
+        std::string helio_api_key = Slic3r::HelioQuery::get_helio_pat();
+        std::string helio_api_url = Slic3r::HelioQuery::get_helio_api_url();
 
         std::string helio_printer_id  = q->get_helio_printer_id_for_the_current_selection().value_or("");
 

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -11,6 +11,7 @@
 #include <regex>
 #include <future>
 #include <thread>
+#include <atomic>
 #include <boost/algorithm/string.hpp>
 #include <boost/nowide/cstdio.hpp>
 #include <boost/iterator/counting_iterator.hpp>
@@ -10768,26 +10769,39 @@ private:
         // Store a copy for the background thread callback
         m_unsupported_copy = unsupported_filaments;
 
-        // Run refresh in background thread to avoid blocking UI
-        m_refresh_thread = std::make_unique<std::thread>([this]() {
-            wxGetApp().request_helio_supported_data(true);
+        // Kick off the refresh from the main thread (safe wxWidgets access)
+        std::string url = HelioQuery::get_helio_api_url();
+        std::string key = HelioQuery::get_helio_pat();
+        if (HelioQuery::request_all_support_machine(url, key, true) ||
+            HelioQuery::request_all_support_materials(url, key, true)) {
+            HelioQuery::clear_print_priority_cache();
+        }
 
-            // Wait for stores to finish loading
+        m_dialog_alive = std::make_shared<std::atomic<bool>>(true);
+        auto alive = m_dialog_alive;
+
+        // Wait for stores to finish loading in a background thread
+        m_refresh_thread = std::make_unique<std::thread>([this, alive]() {
             constexpr int timeout_ms = 60000;
             int elapsed = 0;
-            while (elapsed < timeout_ms &&
+            while (*alive && elapsed < timeout_ms &&
                    (HelioQuery::supported_materials_state() == SupportDataLoadState::Loading ||
                     HelioQuery::supported_printers_state() == SupportDataLoadState::Loading)) {
                 std::this_thread::sleep_for(std::chrono::milliseconds(100));
                 elapsed += 100;
             }
 
-            // Post result back to GUI thread
-            wxTheApp->CallAfter([this]() {
-                on_refresh_complete();
-            });
+            if (*alive) {
+                wxTheApp->CallAfter([this, alive]() {
+                    if (*alive) on_refresh_complete();
+                });
+            }
         });
         m_refresh_thread->detach();
+    }
+
+    ~HelioUnsupportedFilamentsDialog() {
+        if (m_dialog_alive) *m_dialog_alive = false;
     }
 
     void on_refresh_complete() {
@@ -10825,6 +10839,7 @@ private:
     Label* m_refresh_status{nullptr};
     std::vector<FilamentSupportInfo> m_unsupported_copy;
     std::unique_ptr<std::thread> m_refresh_thread;
+    std::shared_ptr<std::atomic<bool>> m_dialog_alive;
 };
 
 // ===========================================================================
@@ -17742,7 +17757,9 @@ int Plater::get_helio_process_status() const
 
 void Plater::set_materials_from_helio()
 {
-    p->helio_elements_fetched = (HelioQuery::supported_materials_state() == SupportDataLoadState::Ready);
+    p->helio_elements_fetched =
+        (HelioQuery::supported_materials_state() == SupportDataLoadState::Ready) &&
+        (HelioQuery::supported_printers_state() == SupportDataLoadState::Ready);
 }
 
 void Plater::set_materials_invalid_from_helio()

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -17814,7 +17814,11 @@ std::optional<std::string> Plater::get_helio_material_id_for_the_current_selecti
 
 std::optional<std::string> Plater::get_helio_printer_id_for_the_current_selection()
 {
-    if (HelioQuery::supported_printers_state() != SupportDataLoadState::Ready)
+    // Use the aggregate availability check (rather than a strict Ready state check) so
+    // that a still-usable last-good snapshot is accepted even after a force refresh has
+    // failed (SupportDataCatalogStore::fail() keeps the previous snapshot around, and
+    // supported_data_availability() reports it as Usable in that case).
+    if (HelioQuery::supported_data_availability() != SupportDataAvailability::Usable)
         return std::nullopt;
 
     // First check printer config for explicit helio_printer_id

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -9965,8 +9965,12 @@ static FilamentSupportInfo check_filament_helio_support(const std::string& filam
     std::string target_name = (atPos != std::string::npos) ? filament_preset_name.substr(0, atPos) : filament_preset_name;
     boost::trim(target_name);
 
+    const auto supported_materials = HelioQuery::supported_materials_snapshot();
+    if (!supported_materials)
+        return info;
+
     size_t best_match_length = 0;
-    for (const HelioQuery::SupportedData& pdata : HelioQuery::global_supported_materials) {
+    for (const HelioQuery::SupportedData& pdata : *supported_materials) {
         if (pdata.native_name.empty()) continue;
 
         std::string native_name = pdata.native_name;
@@ -10027,9 +10031,10 @@ static std::vector<HelioQuery::SupportedData> find_similar_materials(
     const std::vector<std::string>& keywords)
 {
     std::vector<HelioQuery::SupportedData> similar_materials;
-    if (keywords.empty()) return similar_materials;
+    const auto supported_materials = HelioQuery::supported_materials_snapshot();
+    if (keywords.empty() || !supported_materials) return similar_materials;
 
-    for (const HelioQuery::SupportedData& pdata : HelioQuery::global_supported_materials) {
+    for (const HelioQuery::SupportedData& pdata : *supported_materials) {
         if (pdata.native_name.empty()) continue;
         std::string lower_native = pdata.native_name;
         boost::algorithm::to_lower(lower_native);
@@ -10067,15 +10072,18 @@ static std::vector<HelioQuery::SupportedData> find_similar_printers(
     const std::vector<std::string>& keywords)
 {
     std::vector<HelioQuery::SupportedData> similar_printers;
+    const auto supported_printers = HelioQuery::supported_printers_snapshot();
+    if (!supported_printers) return similar_printers;
+
     if (keywords.empty()) {
-        for (const HelioQuery::SupportedData& pdata : HelioQuery::global_supported_printers) {
+        for (const HelioQuery::SupportedData& pdata : *supported_printers) {
             if (!pdata.native_name.empty())
                 similar_printers.push_back(pdata);
         }
         return similar_printers;
     }
 
-    for (const HelioQuery::SupportedData& pdata : HelioQuery::global_supported_printers) {
+    for (const HelioQuery::SupportedData& pdata : *supported_printers) {
         if (pdata.native_name.empty()) continue;
         std::string lower_native = pdata.native_name;
         boost::algorithm::to_lower(lower_native);
@@ -10762,16 +10770,14 @@ private:
 
         // Run refresh in background thread to avoid blocking UI
         m_refresh_thread = std::make_unique<std::thread>([this]() {
-            std::string helio_api_url = HelioQuery::get_helio_api_url();
-            std::string helio_api_key = HelioQuery::get_helio_pat();
-            HelioQuery::request_all_support_materials(helio_api_url, helio_api_key);
-            HelioQuery::request_all_support_machine(helio_api_url, helio_api_key);
+            wxGetApp().request_helio_supported_data(true);
 
-            // Wait for async HTTP requests to complete (Http::perform() is async)
+            // Wait for stores to finish loading
             constexpr int timeout_ms = 60000;
             int elapsed = 0;
             while (elapsed < timeout_ms &&
-                   (!HelioQuery::global_materials_fully_loaded || !HelioQuery::global_printers_fully_loaded)) {
+                   (HelioQuery::supported_materials_state() == SupportDataLoadState::Loading ||
+                    HelioQuery::supported_printers_state() == SupportDataLoadState::Loading)) {
                 std::this_thread::sleep_for(std::chrono::milliseconds(100));
                 elapsed += 100;
             }
@@ -10785,7 +10791,7 @@ private:
     }
 
     void on_refresh_complete() {
-        if (HelioQuery::global_materials_fully_loaded) {
+        if (HelioQuery::supported_data_availability() == SupportDataAvailability::Usable) {
             // Re-check all unsupported filaments
             bool all_now_supported = true;
             for (const auto& info : m_unsupported_copy) {
@@ -10839,8 +10845,16 @@ int Plater::priv::update_helio_background_process_v2(std::string& printer_id, st
         return -1;
     }
 
+    const auto supported_printers = HelioQuery::supported_printers_snapshot();
+    const auto supported_materials = HelioQuery::supported_materials_snapshot();
+    if (HelioQuery::supported_data_availability() != SupportDataAvailability::Usable ||
+        !supported_printers || !supported_materials) {
+        BOOST_LOG_TRIVIAL(error) << __FUNCTION__ << ": Helio support-data snapshot is unavailable";
+        return -1;
+    }
+
     BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << ": preset_name = '" << preset_name << "'";
-    BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << ": global_supported_printers.size() = " << HelioQuery::global_supported_printers.size();
+    BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << ": supported_printers.size() = " << supported_printers->size();
 
     std::string printer_target_name = strip_nozzle_suffix(preset_name, preset_bundle->printers.get_edited_preset());
     boost::trim(printer_target_name);
@@ -10856,7 +10870,7 @@ int Plater::priv::update_helio_background_process_v2(std::string& printer_id, st
 
     // Step 1: Try word-boundary matching
     auto [best_match_id, best_match_length] = match_printer_with_boundaries(
-        printer_target_name, HelioQuery::global_supported_printers);
+        printer_target_name, *supported_printers);
 
     if (!best_match_id.empty()) {
         helio_support = true;
@@ -10867,7 +10881,7 @@ int Plater::priv::update_helio_background_process_v2(std::string& printer_id, st
     // Step 2: Token-based matching
     if (!helio_support) {
         auto [token_printer_id, token_native_name] = match_printer_tokens(
-            printer_target_name, HelioQuery::global_supported_printers);
+            printer_target_name, *supported_printers);
 
         if (!token_printer_id.empty()) {
             wxString message = wxString::Format(
@@ -10989,7 +11003,7 @@ int Plater::priv::update_helio_background_process_v2(std::string& printer_id, st
         size_t best_mat_match_length = 0;
         std::string best_mat_id;
 
-        for (const HelioQuery::SupportedData& pdata : HelioQuery::global_supported_materials) {
+        for (const HelioQuery::SupportedData& pdata : *supported_materials) {
             if (!pdata.native_name.empty()) {
                 std::string native_name = pdata.native_name;
                 size_t atPos = used_filament.find('@');
@@ -11032,7 +11046,7 @@ int Plater::priv::update_helio_background_process_v2(std::string& printer_id, st
             std::string best_token_material_id;
             std::string best_token_native_name;
 
-            for (const HelioQuery::SupportedData& pdata : HelioQuery::global_supported_materials) {
+            for (const HelioQuery::SupportedData& pdata : *supported_materials) {
                 if (!pdata.native_name.empty()) {
                     std::string native_name = pdata.native_name;
                     boost::algorithm::to_lower(native_name);
@@ -11187,6 +11201,14 @@ int Plater::priv::update_helio_background_process(std::string& printer_id,
         return -1;
     }
 
+    const auto supported_printers = HelioQuery::supported_printers_snapshot();
+    const auto supported_materials = HelioQuery::supported_materials_snapshot();
+    if (HelioQuery::supported_data_availability() != SupportDataAvailability::Usable ||
+        !supported_printers || !supported_materials) {
+        BOOST_LOG_TRIVIAL(error) << __FUNCTION__ << ": Helio support-data snapshot is unavailable";
+        return -1;
+    }
+
     BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << ": preset_name = '" << preset_name << "'";
 
     std::string printer_target_name = strip_nozzle_suffix(preset_name, preset_bundle->printers.get_edited_preset());
@@ -11203,7 +11225,7 @@ int Plater::priv::update_helio_background_process(std::string& printer_id,
 
     // Step 1: Word-boundary matching
     auto [best_match_id, best_match_length] = match_printer_with_boundaries(
-        printer_target_name, HelioQuery::global_supported_printers);
+        printer_target_name, *supported_printers);
 
     if (!best_match_id.empty()) {
         helio_support = true;
@@ -11214,7 +11236,7 @@ int Plater::priv::update_helio_background_process(std::string& printer_id,
     // Step 2: Token-based matching
     if (!helio_support) {
         auto [token_printer_id, token_native_name] = match_printer_tokens(
-            printer_target_name, HelioQuery::global_supported_printers);
+            printer_target_name, *supported_printers);
 
         if (!token_printer_id.empty()) {
             wxString message = wxString::Format(
@@ -11328,7 +11350,7 @@ int Plater::priv::update_helio_background_process(std::string& printer_id,
         std::string best_token_material_id;
         std::string best_token_native_name;
 
-        for (const HelioQuery::SupportedData& pdata : HelioQuery::global_supported_materials) {
+        for (const HelioQuery::SupportedData& pdata : *supported_materials) {
             if (pdata.native_name.empty()) continue;
             std::string native_name = pdata.native_name;
             boost::algorithm::to_lower(native_name);
@@ -11566,13 +11588,19 @@ void Plater::priv::on_helio_input_dlg(wxCommandEvent &a)
         }
     }
     else {
-        if (!HelioQuery::global_printers_fully_loaded || !HelioQuery::global_materials_fully_loaded) {
+        const SupportDataAvailability availability = HelioQuery::supported_data_availability();
+        if (availability == SupportDataAvailability::Usable) {
+            on_helio_process();
+        }
+        else if (availability == SupportDataAvailability::Synchronizing) {
             wxGetApp().request_helio_supported_data();
             auto dlg = MessageDialog(nullptr, _L("The printer list and material list are being synchronized. Please try again later."), _L("Synchronizing Helio"), wxOK | wxICON_WARNING);
             dlg.ShowModal();
         }
         else {
-            on_helio_process();
+            wxGetApp().request_helio_supported_data(true);
+            auto dlg = MessageDialog(nullptr, _L("Helio could not load the supported printer and material lists. Please check your network connection and API settings, then try again."), _L("Helio Data Load Failed"), wxOK | wxICON_WARNING);
+            dlg.ShowModal();
         }
     }
 }
@@ -17714,7 +17742,7 @@ int Plater::get_helio_process_status() const
 
 void Plater::set_materials_from_helio()
 {
-    p->helio_elements_fetched = HelioQuery::global_materials_fully_loaded;
+    p->helio_elements_fetched = (HelioQuery::supported_materials_state() == SupportDataLoadState::Ready);
 }
 
 void Plater::set_materials_invalid_from_helio()
@@ -17724,7 +17752,8 @@ void Plater::set_materials_invalid_from_helio()
 
 void Plater::set_printers_from_helio()
 {
-    p->helio_elements_fetched = p->helio_elements_fetched && HelioQuery::global_printers_fully_loaded;
+    p->helio_elements_fetched = p->helio_elements_fetched &&
+        (HelioQuery::supported_printers_state() == SupportDataLoadState::Ready);
 }
 
 void Plater::set_printers_invalid_from_helio()
@@ -17744,7 +17773,7 @@ void Plater::set_helio_elements_have_been_loaded(bool status)
 
 std::optional<std::string> Plater::get_helio_material_id_for_the_current_selection(size_t extruder_id)
 {
-    if (!HelioQuery::global_materials_fully_loaded)
+    if (HelioQuery::supported_materials_state() != SupportDataLoadState::Ready)
         return std::nullopt;
 
     // Get current filament preset name for the given extruder
@@ -17758,7 +17787,7 @@ std::optional<std::string> Plater::get_helio_material_id_for_the_current_selecti
 
 std::optional<std::string> Plater::get_helio_printer_id_for_the_current_selection()
 {
-    if (!HelioQuery::global_printers_fully_loaded)
+    if (HelioQuery::supported_printers_state() != SupportDataLoadState::Ready)
         return std::nullopt;
 
     // First check printer config for explicit helio_printer_id
@@ -17776,6 +17805,9 @@ std::optional<std::string> Plater::get_helio_printer_id_for_the_current_selectio
 
 std::optional<std::string> Plater::get_material_id_from_name(std::string name)
 {
+    const auto supported_materials = HelioQuery::supported_materials_snapshot();
+    if (!supported_materials) return std::nullopt;
+
     // Split at '@' and trim (filament presets are often "PLA @Printer")
     auto at_pos = name.find('@');
     std::string search_name = (at_pos != std::string::npos) ? name.substr(0, at_pos) : name;
@@ -17783,7 +17815,7 @@ std::optional<std::string> Plater::get_material_id_from_name(std::string name)
     while (!search_name.empty() && search_name.back() == ' ')
         search_name.pop_back();
 
-    for (auto& mat : HelioQuery::global_supported_materials) {
+    for (auto& mat : *supported_materials) {
         if (boost::algorithm::iequals(mat.name, search_name) ||
             (!mat.native_name.empty() && boost::algorithm::iequals(mat.native_name, search_name)))
             return mat.id;
@@ -17793,7 +17825,10 @@ std::optional<std::string> Plater::get_material_id_from_name(std::string name)
 
 std::optional<std::string> Plater::get_printer_id_from_name(std::string name)
 {
-    for (auto& pr : HelioQuery::global_supported_printers) {
+    const auto supported_printers = HelioQuery::supported_printers_snapshot();
+    if (!supported_printers) return std::nullopt;
+
+    for (auto& pr : *supported_printers) {
         if (boost::algorithm::icontains(name, pr.name) ||
             (!pr.native_name.empty() && boost::algorithm::icontains(name, pr.native_name)))
             return pr.id;

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -10800,14 +10800,16 @@ private:
         // in-flight load briefly leaves the Loading state before the worker picks up
         // the pending flag and re-enters Loading.
         m_refresh_thread = std::make_unique<std::thread>([this, alive]() {
-            // The deadline has to cover the store's whole request budget, not a single
-            // request: helio_fetch_support_data_page() allows 100s per attempt and the
-            // store permits MAX_ATTEMPTS_PER_PAGE attempts plus backoff waits between
-            // them. At 60s this loop exited while a catalog was still Loading, so
-            // on_refresh_complete() reported failure (or re-checked the stale snapshot)
-            // while the original fetch was still running, and re-enabling the button let
-            // repeated clicks queue redundant loads.
-            constexpr int timeout_ms = 480000;
+            // Wait for the stores to reach a terminal state rather than for a fixed
+            // budget: MAX_ATTEMPTS_PER_PAGE applies independently to every page, so no
+            // single-page budget bounds a paginated walk. Exiting early re-enabled the
+            // button while the fetch was still running, and another click queued a
+            // redundant force refresh that restarts the whole walk.
+            //
+            // The cap below is only a safety net against a wedged worker leaking this
+            // detached thread; the loop normally ends when the stores settle, and ends
+            // immediately when the dialog is destroyed (alive flag).
+            constexpr int timeout_ms = 1800000;
             int elapsed = 0;
             while (*alive && elapsed < timeout_ms &&
                    (HelioQuery::supported_materials_state() == SupportDataLoadState::Loading ||
@@ -10829,9 +10831,20 @@ private:
     void on_refresh_complete() {
         const SupportDataAvailability availability = HelioQuery::supported_data_availability();
         if (availability == SupportDataAvailability::Synchronizing) {
-            // The deadline elapsed with a load still in flight — don't call that a
+            // The safety cap elapsed with a load still in flight — don't call that a
             // failure, the fetch may still succeed.
             m_refresh_status->SetLabel(_L("Still synchronizing supported materials. Please try again in a moment."));
+            m_refresh_button->Enable(true);
+            Layout();
+            Fit();
+            return;
+        }
+        // A failed refresh keeps the previous snapshot, so availability can still be
+        // Usable here. Report that as a refresh failure rather than re-checking the
+        // unchanged catalog and telling the user the materials are still unsupported.
+        if (HelioQuery::supported_materials_state() == SupportDataLoadState::Failed ||
+            HelioQuery::supported_printers_state() == SupportDataLoadState::Failed) {
+            m_refresh_status->SetLabel(_L("Refresh failed. Please try again later."));
             m_refresh_button->Enable(true);
             Layout();
             Fit();

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -10758,6 +10758,10 @@ public:
     int get_user_choice() const { return m_user_choice; }
     std::string get_selected_material_id() const { return m_selected_material_id; }
 
+    ~HelioUnsupportedFilamentsDialog() {
+        if (m_dialog_alive) *m_dialog_alive = false;
+    }
+
 private:
     void on_refresh_and_retry(const std::vector<FilamentSupportInfo>& unsupported_filaments) {
         m_refresh_button->Enable(false);
@@ -10772,8 +10776,9 @@ private:
         // Kick off the refresh from the main thread (safe wxWidgets access)
         std::string url = HelioQuery::get_helio_api_url();
         std::string key = HelioQuery::get_helio_pat();
-        if (HelioQuery::request_all_support_machine(url, key, true) ||
-            HelioQuery::request_all_support_materials(url, key, true)) {
+        bool printers_started  = HelioQuery::request_all_support_machine(url, key, true);
+        bool materials_started = HelioQuery::request_all_support_materials(url, key, true);
+        if (printers_started || materials_started) {
             HelioQuery::clear_print_priority_cache();
         }
 
@@ -10798,10 +10803,6 @@ private:
             }
         });
         m_refresh_thread->detach();
-    }
-
-    ~HelioUnsupportedFilamentsDialog() {
-        if (m_dialog_alive) *m_dialog_alive = false;
     }
 
     void on_refresh_complete() {

--- a/src/slic3r/GUI/Preferences.cpp
+++ b/src/slic3r/GUI/Preferences.cpp
@@ -410,6 +410,9 @@ wxBoxSizer *PreferencesDialog::create_item_region_combobox(wxString title, wxStr
             } else {
                 wxGetApp().request_user_logout();
                 config->set("region", region.ToStdString());
+                // The Helio endpoint and the regional PAT key both follow "region",
+                // so the catalogs loaded from the previous endpoint must go.
+                Slic3r::HelioQuery::invalidate_support_data_for_endpoint_change();
                 auto area = config->get_country_code();
                 if (agent) {
                     agent->set_country_code(area);
@@ -418,6 +421,7 @@ wxBoxSizer *PreferencesDialog::create_item_region_combobox(wxString title, wxStr
             }
         } else {
             config->set("region", region.ToStdString());
+            Slic3r::HelioQuery::invalidate_support_data_for_endpoint_change();
         }
 
         wxGetApp().update_publish_status();

--- a/src/slic3r/GUI/WebGuideDialog.cpp
+++ b/src/slic3r/GUI/WebGuideDialog.cpp
@@ -12,6 +12,7 @@
 #include "libslic3r/PresetBundle.hpp"
 #include "slic3r/GUI/wxExtensions.hpp"
 #include "slic3r/GUI/GUI_App.hpp"
+#include "slic3r/Utils/HelioDragon.hpp"
 #include "libslic3r_version.h"
 
 #include <wx/sizer.h>
@@ -665,7 +666,13 @@ int GuideFrame::SaveProfile()
     // } else
     //     m_MainPtr->app_config->set(std::string(m_SectionName.mb_str()), "privacyuse", "0");
 
+    const bool region_changed = m_MainPtr->app_config->get("region") != m_Region;
     m_MainPtr->app_config->set("region", m_Region);
+    if (region_changed) {
+        // Region selects both the Helio endpoint and which regional PAT key is read,
+        // so catalogs loaded from the previous endpoint must not survive the switch.
+        Slic3r::HelioQuery::invalidate_support_data_for_endpoint_change();
+    }
     m_MainPtr->app_config->set_bool("stealth_mode", StealthMode);
 
     //finish

--- a/src/slic3r/Utils/HelioDragon.cpp
+++ b/src/slic3r/Utils/HelioDragon.cpp
@@ -38,6 +38,10 @@ static std::atomic<std::uint64_t> g_helio_credential_generation{0};
 // read and written off the main thread.
 static std::mutex g_helio_priority_cache_mutex;
 
+// Tag for a request whose credential was already superseded when it was issued. The
+// counter only ever increments from 0, so this value never matches a real generation.
+static constexpr std::uint64_t HELIO_STALE_CREDENTIAL_GENERATION = UINT64_MAX;
+
 std::string HelioQuery::last_simulation_trace_id;
 std::string HelioQuery::last_optimization_trace_id;
 
@@ -526,7 +530,15 @@ void HelioQuery::request_print_priority_options(
     // Print priority options are account-scoped. Remember which credentials this request
     // was issued with so a response that lands after a PAT change is discarded instead of
     // refilling the cache that the credential change just cleared.
-    const std::uint64_t request_generation = credential_generation();
+    //
+    // The generation is read *before* re-reading the configured PAT: if the credential
+    // changed between the caller reading helio_api_key and this point, the comparison
+    // below fails and the request is tagged with a generation that can never match any
+    // real one, so its response is dropped rather than cached under the new account.
+    std::uint64_t request_generation = credential_generation();
+    if (helio_api_key != get_helio_pat()) {
+        request_generation = HELIO_STALE_CREDENTIAL_GENERATION;
+    }
     http.timeout_connect(10)
         .timeout_max(30)
         .on_header_callback([response_headers](std::string headers) {

--- a/src/slic3r/Utils/HelioDragon.cpp
+++ b/src/slic3r/Utils/HelioDragon.cpp
@@ -369,9 +369,10 @@ SupportDataCatalogStore& helio_materials_store()
 bool helio_request_support_data(SupportDataCatalogStore& store,
                                 const std::string& helio_api_url,
                                 const std::string& helio_api_key,
-                                bool force_refresh)
+                                bool force_refresh,
+                                bool already_began = false)
 {
-    if (!store.try_begin(force_refresh)) {
+    if (!already_began && !store.try_begin(force_refresh)) {
         return false;
     }
 
@@ -403,8 +404,10 @@ bool helio_request_support_data(SupportDataCatalogStore& store,
             // while this load was already in flight; try_begin() queues it instead of
             // dropping it (see SupportDataCatalogStore::try_begin()). Honor it now with
             // freshly-read credentials, since the ones this run used may already be stale.
-            if (!stopping.load(std::memory_order_acquire) && store.consume_pending_refresh()) {
-                helio_request_support_data(store, HelioQuery::get_helio_api_url(), HelioQuery::get_helio_pat(), true);
+            // begin_pending_refresh() atomically clears the flag AND transitions to Loading
+            // so the GUI never observes Ready/Failed with no pending flag in between.
+            if (!stopping.load(std::memory_order_acquire) && store.begin_pending_refresh()) {
+                helio_request_support_data(store, HelioQuery::get_helio_api_url(), HelioQuery::get_helio_pat(), true, true);
             }
         });
 
@@ -641,14 +644,22 @@ void HelioQuery::set_helio_pat(std::string pat)
         });
     }
 
-    if (!pat.empty() && pat != old_pat) {
-        BOOST_LOG_TRIVIAL(info) << "Helio PAT changed — force-refreshing support data";
-        if (!GUI::wxGetApp().app_config->get_bool("enable_helio_processing"))
+    if (pat != old_pat) {
+        BOOST_LOG_TRIVIAL(info) << "Helio PAT changed — invalidating caches";
+        clear_print_priority_cache();
+
+        if (pat.empty() || !GUI::wxGetApp().app_config->get_bool("enable_helio_processing")) {
+            // PAT removed (logout) or Helio disabled: invalidate snapshots so stale data
+            // from the previous account is never used. When Helio is re-enabled, the
+            // non-forced request_helio_supported_data() will see NotLoaded and reload.
+            helio_printers_store().invalidate();
+            helio_materials_store().invalidate();
             return;
+        }
+        BOOST_LOG_TRIVIAL(info) << "Helio PAT changed — force-refreshing support data";
         const std::string url = get_helio_api_url();
         request_all_support_machine(url, pat, true);
         request_all_support_materials(url, pat, true);
-        clear_print_priority_cache();
     }
 }
 

--- a/src/slic3r/Utils/HelioDragon.cpp
+++ b/src/slic3r/Utils/HelioDragon.cpp
@@ -609,10 +609,19 @@ std::string HelioQuery::get_helio_pat()
 
 void HelioQuery::set_helio_pat(std::string pat)
 {
+    const std::string old_pat = get_helio_pat();
     if (GUI::wxGetApp().app_config->get("region") == "China") {
         GUI::wxGetApp().app_config->set("helio_pat_china", pat);
     } else {
         GUI::wxGetApp().app_config->set("helio_pat_other", pat);
+    }
+    GUI::wxGetApp().app_config->set("helio_access_token", pat);
+
+    if (!pat.empty() && pat != old_pat) {
+        BOOST_LOG_TRIVIAL(info) << "Helio PAT changed — force-refreshing support data";
+        const std::string url = get_helio_api_url();
+        request_all_support_machine(url, pat, true);
+        request_all_support_materials(url, pat, true);
     }
 }
 

--- a/src/slic3r/Utils/HelioDragon.cpp
+++ b/src/slic3r/Utils/HelioDragon.cpp
@@ -470,6 +470,11 @@ SupportDataAvailability HelioQuery::supported_data_availability()
     return Slic3r::support_data_availability(helio_printers_store().view(), helio_materials_store().view());
 }
 
+bool HelioQuery::has_pending_support_data_refresh()
+{
+    return helio_printers_store().has_pending_refresh() || helio_materials_store().has_pending_refresh();
+}
+
 void HelioQuery::shutdown_background_requests()
 {
     helio_request_workers().shutdown();
@@ -628,13 +633,22 @@ void HelioQuery::set_helio_pat(std::string pat)
     // function, so the regional helio_pat_china/helio_pat_other key set just above would
     // otherwise remain unsaved in memory only. Persist it now so get_helio_pat() (which
     // reads the regional key) reflects the latest PAT after a restart.
-    GUI::wxGetApp().app_config->save();
+    // AppConfig::save() must run on the main thread — dispatch via CallAfter so callers
+    // from HTTP worker threads (e.g. request_pat_token) don't trigger a CriticalException.
+    if (wxTheApp) {
+        wxTheApp->CallAfter([]() {
+            GUI::wxGetApp().app_config->save();
+        });
+    }
 
     if (!pat.empty() && pat != old_pat) {
         BOOST_LOG_TRIVIAL(info) << "Helio PAT changed — force-refreshing support data";
+        if (!GUI::wxGetApp().app_config->get_bool("enable_helio_processing"))
+            return;
         const std::string url = get_helio_api_url();
         request_all_support_machine(url, pat, true);
         request_all_support_materials(url, pat, true);
+        clear_print_priority_cache();
     }
 }
 

--- a/src/slic3r/Utils/HelioDragon.cpp
+++ b/src/slic3r/Utils/HelioDragon.cpp
@@ -398,6 +398,14 @@ bool helio_request_support_data(SupportDataCatalogStore& store,
                         << ", trace-id=" << attempt.trace_id
                         << ", error=" << attempt.error;
                 });
+
+            // A force-refresh (e.g. the user linking/replacing a PAT) may have arrived
+            // while this load was already in flight; try_begin() queues it instead of
+            // dropping it (see SupportDataCatalogStore::try_begin()). Honor it now with
+            // freshly-read credentials, since the ones this run used may already be stale.
+            if (!stopping.load(std::memory_order_acquire) && store.consume_pending_refresh()) {
+                helio_request_support_data(store, HelioQuery::get_helio_api_url(), HelioQuery::get_helio_pat(), true);
+            }
         });
 
     if (!worker_started) {
@@ -616,6 +624,11 @@ void HelioQuery::set_helio_pat(std::string pat)
         GUI::wxGetApp().app_config->set("helio_pat_other", pat);
     }
     GUI::wxGetApp().app_config->set("helio_access_token", pat);
+    // Callers commonly save the app config for "helio_access_token" *before* calling this
+    // function, so the regional helio_pat_china/helio_pat_other key set just above would
+    // otherwise remain unsaved in memory only. Persist it now so get_helio_pat() (which
+    // reads the regional key) reflects the latest PAT after a restart.
+    GUI::wxGetApp().app_config->save();
 
     if (!pat.empty() && pat != old_pat) {
         BOOST_LOG_TRIVIAL(info) << "Helio PAT changed — force-refreshing support data";

--- a/src/slic3r/Utils/HelioDragon.cpp
+++ b/src/slic3r/Utils/HelioDragon.cpp
@@ -30,6 +30,9 @@ namespace Slic3r {
 
 std::map<std::string, std::vector<HelioQuery::PrintPriorityOption>> HelioQuery::global_print_priority_cache;
 
+// Bumped on every PAT change; see HelioQuery::credential_generation().
+static std::atomic<std::uint64_t> g_helio_credential_generation{0};
+
 std::string HelioQuery::last_simulation_trace_id;
 std::string HelioQuery::last_optimization_trace_id;
 
@@ -515,18 +518,33 @@ void HelioQuery::request_print_priority_options(
 
     // Use shared_ptr to prevent stack corruption in async callbacks
     auto response_headers = std::make_shared<std::string>();
+    // Print priority options are account-scoped. Remember which credentials this request
+    // was issued with so a response that lands after a PAT change is discarded instead of
+    // refilling the cache that the credential change just cleared.
+    const std::uint64_t request_generation = credential_generation();
     http.timeout_connect(10)
         .timeout_max(30)
         .on_header_callback([response_headers](std::string headers) {
             *response_headers += headers;
         })
-        .on_complete([callback, material_id, response_headers](std::string body, unsigned status) {
+        .on_complete([callback, material_id, response_headers, request_generation](std::string body, unsigned status) {
             BOOST_LOG_TRIVIAL(info) << "request_print_priority_options response: " << body;
 
             GetPrintPriorityOptionsResult result;
             result.status = status;
             result.success = false;
             result.trace_id = extract_trace_id(*response_headers);
+
+            if (request_generation != credential_generation()) {
+                // The PAT changed while this request was in flight — these options belong
+                // to the previous account. Report a failure so the caller falls back to
+                // the standard options rather than showing another account's data.
+                result.error = "Helio credentials changed while loading print priority options";
+                BOOST_LOG_TRIVIAL(info) << "request_print_priority_options: discarding response from a "
+                                           "superseded Helio credential";
+                callback(result);
+                return;
+            }
 
             try {
                 nlohmann::json parsed_obj = nlohmann::json::parse(body);
@@ -601,6 +619,16 @@ void HelioQuery::clear_print_priority_cache()
     global_print_priority_cache.clear();
 }
 
+std::uint64_t HelioQuery::credential_generation()
+{
+    return g_helio_credential_generation.load(std::memory_order_acquire);
+}
+
+void HelioQuery::bump_credential_generation()
+{
+    g_helio_credential_generation.fetch_add(1, std::memory_order_acq_rel);
+}
+
 std::string HelioQuery::get_helio_api_url()
 {
     std::string helio_api_url;
@@ -646,6 +674,9 @@ void HelioQuery::set_helio_pat(std::string pat)
 
     if (pat != old_pat) {
         BOOST_LOG_TRIVIAL(info) << "Helio PAT changed — invalidating caches";
+        // Bump before clearing: account-scoped requests already in flight capture the old
+        // generation and will drop their responses instead of refilling the cleared cache.
+        bump_credential_generation();
         clear_print_priority_cache();
 
         if (pat.empty() || !GUI::wxGetApp().app_config->get_bool("enable_helio_processing")) {

--- a/src/slic3r/Utils/HelioDragon.cpp
+++ b/src/slic3r/Utils/HelioDragon.cpp
@@ -664,6 +664,19 @@ void HelioQuery::invalidate_account_scoped_caches()
     global_print_priority_cache.clear();
 }
 
+void HelioQuery::invalidate_support_data_for_endpoint_change()
+{
+    BOOST_LOG_TRIVIAL(info) << "Helio endpoint/region changed — invalidating support data";
+    // Switching region changes both the API endpoint and which regional PAT key is read,
+    // without going through set_helio_pat(). Without this, the snapshots loaded from the
+    // previous endpoint stay in place and an ordinary (non-forced)
+    // request_helio_supported_data() would keep them, letting printer/material IDs from
+    // the old region be used with the newly selected region's credential.
+    invalidate_account_scoped_caches();
+    helio_printers_store().invalidate();
+    helio_materials_store().invalidate();
+}
+
 std::string HelioQuery::get_helio_api_url()
 {
     std::string helio_api_url;

--- a/src/slic3r/Utils/HelioDragon.cpp
+++ b/src/slic3r/Utils/HelioDragon.cpp
@@ -313,7 +313,7 @@ SupportDataHttpResponse helio_fetch_support_data_page(SupportDataCatalogKind kin
 {
     const char* query = kind == SupportDataCatalogKind::Printers
         ? "query GetPrinters($page: Int) { printers(page: $page, pageSize: 20) { pages pageInfo { hasNextPage } objects { ... on Printer  { id name heatedChamber alternativeNames { bambustudio } } } } }"
-        : "query GetMaterias($page: Int) { materials(page: $page, pageSize: 20) { pages pageInfo { hasNextPage } objects { ... on Material  { id name feedstock alternativeNames { bambustudio } } } } }";
+        : "query GetMaterials($page: Int) { materials(page: $page, pageSize: 20) { pages pageInfo { hasNextPage } objects { ... on Material  { id name feedstock alternativeNames { bambustudio } } } } }";
 
     nlohmann::json request_body;
     request_body["query"] = query;

--- a/src/slic3r/Utils/HelioDragon.cpp
+++ b/src/slic3r/Utils/HelioDragon.cpp
@@ -33,6 +33,11 @@ std::map<std::string, std::vector<HelioQuery::PrintPriorityOption>> HelioQuery::
 // Bumped on every PAT change; see HelioQuery::credential_generation().
 static std::atomic<std::uint64_t> g_helio_credential_generation{0};
 
+// Guards global_print_priority_cache and serializes it with the generation bump.
+// Http::perform() runs completion callbacks on an I/O thread, so the cache is both
+// read and written off the main thread.
+static std::mutex g_helio_priority_cache_mutex;
+
 std::string HelioQuery::last_simulation_trace_id;
 std::string HelioQuery::last_optimization_trace_id;
 
@@ -536,9 +541,11 @@ void HelioQuery::request_print_priority_options(
             result.trace_id = extract_trace_id(*response_headers);
 
             if (request_generation != credential_generation()) {
-                // The PAT changed while this request was in flight — these options belong
-                // to the previous account. Report a failure so the caller falls back to
-                // the standard options rather than showing another account's data.
+                // Cheap early-out; the authoritative check happens under the cache lock
+                // at insertion time. The PAT changed while this request was in flight —
+                // these options belong to the previous account. Report a failure so the
+                // caller falls back to the standard options rather than showing another
+                // account's data.
                 result.error = "Helio credentials changed while loading print priority options";
                 BOOST_LOG_TRIVIAL(info) << "request_print_priority_options: discarding response from a "
                                            "superseded Helio credential";
@@ -572,8 +579,20 @@ void HelioQuery::request_print_priority_options(
                         }
                         result.success = true;
 
-                        // Cache the results
-                        global_print_priority_cache[material_id] = result.options;
+                        // Cache the results. The generation re-check and the insertion
+                        // share the lock that set_helio_pat() uses to bump the generation
+                        // and clear the cache, so a PAT change can't slip between them and
+                        // let this response repopulate the cache it just cleared.
+                        std::lock_guard<std::mutex> lock(g_helio_priority_cache_mutex);
+                        if (request_generation != g_helio_credential_generation.load(std::memory_order_acquire)) {
+                            result.success = false;
+                            result.options.clear();
+                            result.error = "Helio credentials changed while loading print priority options";
+                            BOOST_LOG_TRIVIAL(info) << "request_print_priority_options: discarding response from a "
+                                                       "superseded Helio credential";
+                        } else {
+                            global_print_priority_cache[material_id] = result.options;
+                        }
                     }
                 } else if (parsed_obj.contains("errors")) {
                     // GraphQL errors
@@ -607,6 +626,7 @@ std::vector<HelioQuery::PrintPriorityOption> HelioQuery::get_cached_print_priori
     const std::string& material_id
 )
 {
+    std::lock_guard<std::mutex> lock(g_helio_priority_cache_mutex);
     auto it = global_print_priority_cache.find(material_id);
     if (it != global_print_priority_cache.end()) {
         return it->second;
@@ -616,6 +636,7 @@ std::vector<HelioQuery::PrintPriorityOption> HelioQuery::get_cached_print_priori
 
 void HelioQuery::clear_print_priority_cache()
 {
+    std::lock_guard<std::mutex> lock(g_helio_priority_cache_mutex);
     global_print_priority_cache.clear();
 }
 
@@ -624,9 +645,11 @@ std::uint64_t HelioQuery::credential_generation()
     return g_helio_credential_generation.load(std::memory_order_acquire);
 }
 
-void HelioQuery::bump_credential_generation()
+void HelioQuery::invalidate_account_scoped_caches()
 {
+    std::lock_guard<std::mutex> lock(g_helio_priority_cache_mutex);
     g_helio_credential_generation.fetch_add(1, std::memory_order_acq_rel);
+    global_print_priority_cache.clear();
 }
 
 std::string HelioQuery::get_helio_api_url()
@@ -674,17 +697,23 @@ void HelioQuery::set_helio_pat(std::string pat)
 
     if (pat != old_pat) {
         BOOST_LOG_TRIVIAL(info) << "Helio PAT changed — invalidating caches";
-        // Bump before clearing: account-scoped requests already in flight capture the old
-        // generation and will drop their responses instead of refilling the cleared cache.
-        bump_credential_generation();
-        clear_print_priority_cache();
+        // Bumps the credential generation and clears the print-priority cache under one
+        // lock, so account-scoped requests already in flight drop their responses instead
+        // of refilling the cleared cache.
+        invalidate_account_scoped_caches();
+
+        // Invalidate the catalogs unconditionally, before deciding whether to reload.
+        // This revokes any run started with the previous PAT (so it can't publish) and
+        // drops its snapshot, rather than leaving the old account's catalog Usable until
+        // a replacement load finishes. A force-refresh alone would not do this: against
+        // an in-flight load try_begin(true) only queues a pending refresh.
+        helio_printers_store().invalidate();
+        helio_materials_store().invalidate();
 
         if (pat.empty() || !GUI::wxGetApp().app_config->get_bool("enable_helio_processing")) {
-            // PAT removed (logout) or Helio disabled: invalidate snapshots so stale data
-            // from the previous account is never used. When Helio is re-enabled, the
-            // non-forced request_helio_supported_data() will see NotLoaded and reload.
-            helio_printers_store().invalidate();
-            helio_materials_store().invalidate();
+            // PAT removed (logout) or Helio disabled: leave the stores NotLoaded. When
+            // Helio is re-enabled, the non-forced request_helio_supported_data() sees no
+            // snapshot and reloads with the current credentials.
             return;
         }
         BOOST_LOG_TRIVIAL(info) << "Helio PAT changed — force-refreshing support data";

--- a/src/slic3r/Utils/HelioDragon.cpp
+++ b/src/slic3r/Utils/HelioDragon.cpp
@@ -334,6 +334,10 @@ SupportDataHttpResponse helio_fetch_support_data_page(SupportDataCatalogKind kin
         .set_post_body(request_body.dump())
         .timeout_connect(20)
         .timeout_max(100)
+        .on_progress([&stopping](Http::Progress, bool& cancel) {
+            if (stopping.load(std::memory_order_acquire))
+                cancel = true;
+        })
         .on_complete([&response](std::string body, unsigned status) {
             response.status = status;
             response.body   = std::move(body);

--- a/src/slic3r/Utils/HelioDragon.cpp
+++ b/src/slic3r/Utils/HelioDragon.cpp
@@ -1,5 +1,6 @@
 #include "HelioDragon.hpp"
 
+#include <atomic>
 #include <string>
 #include <wx/string.h>
 #include <wx/file.h>
@@ -8,6 +9,7 @@
 #include <vector>
 #include <boost/format.hpp>
 #include "PrintHost.hpp"
+#include "Http.hpp"
 #include "libslic3r/Thread.hpp"
 #include "libslic3r/PrintConfig.hpp"
 #include "libslic3r/PrintBase.hpp"
@@ -26,10 +28,6 @@
 
 namespace Slic3r {
 
-std::vector<HelioQuery::SupportedData> HelioQuery::global_supported_printers;
-std::vector<HelioQuery::SupportedData> HelioQuery::global_supported_materials;
-bool HelioQuery::global_printers_fully_loaded = false;
-bool HelioQuery::global_materials_fully_loaded = false;
 std::map<std::string, std::vector<HelioQuery::PrintPriorityOption>> HelioQuery::global_print_priority_cache;
 
 std::string HelioQuery::last_simulation_trace_id;
@@ -228,188 +226,241 @@ void HelioQuery::request_remaining_optimizations(const std::string & helio_api_u
         .perform();
 }
 
-void HelioQuery::request_support_machine(const std::string helio_api_url, const std::string helio_api_key, int page, int retries_left)
+namespace {
+
+class HelioRequestWorkers
 {
-    std::string query_body = R"( {
-            "query": "query GetPrinters($page: Int) { printers(page: $page, pageSize: 20) { pages pageInfo { hasNextPage } objects { ... on Printer  { id name heatedChamber alternativeNames { bambustudio } } } } }",
-            "variables": {"page": %1%}
-		} )";
+public:
+    using Task = std::function<void(const std::atomic_bool&)>;
 
-    query_body = boost::str(boost::format(query_body) % page);
-
-    std::string url_copy  = helio_api_url;
-    std::string key_copy  = helio_api_key;
-    int         page_copy = page;
-
-    std::string response_headers;
-    auto http = Http::post(url_copy);
-
-    http.header("Content-Type", "application/json")
-        .header("Authorization", "Bearer " + helio_api_key)
-        .header("HelioAdditive-Client-Name", SLIC3R_APP_NAME)
-        .header("HelioAdditive-Client-Version", helio_client_version())
-        .set_post_body(query_body);
-
-    http.timeout_connect(20)
-        .timeout_max(100)
-        .on_complete([url_copy, key_copy, page_copy, retries_left](std::string body, unsigned status) {
-            nlohmann::json                         parsed_obj = nlohmann::json::parse(body);
-            std::vector<HelioQuery::SupportedData> supported_printers;
-
-            try {
-                if (parsed_obj.contains("data") && parsed_obj["data"].contains("printers")) {
-                    auto materials = parsed_obj["data"]["printers"];
-                    if (materials.contains("objects") && materials["objects"].is_array()) {
-                        for (const auto &pobj : materials["objects"]) {
-                            HelioQuery::SupportedData sp;
-                            if (pobj.contains("id") && !pobj["id"].is_null()) { sp.id = pobj["id"].get<std::string>(); }
-                            if (pobj.contains("name") && !pobj["id"].is_null()) { sp.name = pobj["name"].get<std::string>(); }
-                            if (pobj.contains("heatedChamber") && pobj["heatedChamber"].is_boolean()) { sp.heated_chamber = pobj["heatedChamber"].get<bool>(); }
-
-                            if (pobj.contains("alternativeNames") && pobj["alternativeNames"].is_object()) {
-                                auto alternativeNames = pobj["alternativeNames"];
-
-                                if (alternativeNames.contains("bambustudio") && !alternativeNames["bambustudio"].is_null()) {
-                                    sp.native_name = alternativeNames["bambustudio"].get<std::string>();
-                                }
-                            }
-
-                            supported_printers.push_back(sp);
-                        }
-                    }
-
-                    HelioQuery::global_supported_printers.insert(HelioQuery::global_supported_printers.end(), supported_printers.begin(), supported_printers.end());
-
-                    if (materials.contains("pageInfo") && materials["pageInfo"].contains("hasNextPage") && materials["pageInfo"]["hasNextPage"].get<bool>()) {
-                        HelioQuery::request_support_machine(url_copy, key_copy, page_copy + 1, retries_left);
-                    } else {
-                        HelioQuery::global_printers_fully_loaded = true;
-                        BOOST_LOG_TRIVIAL(info) << "Helio: all printer pages loaded, total: " << HelioQuery::global_supported_printers.size();
-                    }
+    bool start(Task task)
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        if (m_stopping.load(std::memory_order_acquire)) {
+            return false;
+        }
+        reap_finished_locked();
+        auto finished = std::make_shared<std::atomic_bool>(false);
+        try {
+            m_workers.reserve(m_workers.size() + 1);
+            m_workers.emplace_back();
+            Worker& worker = m_workers.back();
+            worker.finished = finished;
+            worker.thread = std::thread([this, task = std::move(task), finished]() mutable {
+                try {
+                    task(m_stopping);
+                } catch (...) {
                 }
-            } catch (const std::exception& e) {
-                BOOST_LOG_TRIVIAL(error) << "Helio request_support_machine (page " << page_copy << ", retries=" << retries_left << "): " << e.what();
-                if (retries_left > 0) {
-                    std::this_thread::sleep_for(std::chrono::seconds(2));
-                    HelioQuery::request_support_machine(url_copy, key_copy, page_copy, retries_left - 1);
-                } else {
-                    HelioQuery::global_printers_fully_loaded = true;
-                }
-            } catch (...) {
-                BOOST_LOG_TRIVIAL(error) << "Helio request_support_machine (page " << page_copy << ", retries=" << retries_left << "): unknown error";
-                if (retries_left > 0) {
-                    std::this_thread::sleep_for(std::chrono::seconds(2));
-                    HelioQuery::request_support_machine(url_copy, key_copy, page_copy, retries_left - 1);
-                } else {
-                    HelioQuery::global_printers_fully_loaded = true;
-                }
+                finished->store(true, std::memory_order_release);
+            });
+        } catch (...) {
+            if (!m_workers.empty() && m_workers.back().finished == finished &&
+                !m_workers.back().thread.joinable()) {
+                m_workers.pop_back();
             }
-        })
-        .on_error([url_copy, key_copy, page_copy, retries_left](std::string body, std::string error, unsigned status) {
-            BOOST_LOG_TRIVIAL(error) << "request_support_machine error (page " << page_copy << ", retries=" << retries_left << "): " << error << ", status: " << status << ", body: " << body;
-            if (retries_left > 0) {
-                std::this_thread::sleep_for(std::chrono::seconds(2));
-                HelioQuery::request_support_machine(url_copy, key_copy, page_copy, retries_left - 1);
-            } else {
-                HelioQuery::global_printers_fully_loaded = true;
+            return false;
+        }
+        return true;
+    }
+
+    void shutdown()
+    {
+        std::vector<Worker> workers;
+        {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            m_stopping.store(true, std::memory_order_release);
+            workers.swap(m_workers);
+        }
+        for (Worker& worker : workers) {
+            if (worker.thread.joinable()) {
+                worker.thread.join();
             }
-        })
-        .perform();
+        }
+    }
+
+private:
+    struct Worker { std::thread thread; std::shared_ptr<std::atomic_bool> finished; };
+
+    void reap_finished_locked()
+    {
+        m_workers.erase(
+            std::remove_if(m_workers.begin(), m_workers.end(), [](Worker& w) {
+                if (w.finished && w.finished->load(std::memory_order_acquire)) {
+                    if (w.thread.joinable()) w.thread.join();
+                    return true;
+                }
+                return false;
+            }),
+            m_workers.end());
+    }
+
+    std::mutex          m_mutex;
+    std::atomic_bool    m_stopping{false};
+    std::vector<Worker> m_workers;
+};
+
+HelioRequestWorkers& helio_request_workers()
+{
+    static HelioRequestWorkers* workers = new HelioRequestWorkers;
+    return *workers;
 }
 
-void HelioQuery::request_support_material(const std::string helio_api_url, const std::string helio_api_key, int page, int retries_left)
+SupportDataHttpResponse helio_fetch_support_data_page(SupportDataCatalogKind kind,
+                                                       const std::string& helio_api_url,
+                                                       const std::string& helio_api_key,
+                                                       int page,
+                                                       const std::atomic_bool& stopping)
 {
-    std::string query_body = R"( {
-			"query": "query GetMaterias($page: Int) { materials(page: $page, pageSize: 20) { pages pageInfo { hasNextPage } objects { ... on Material  { id name feedstock alternativeNames { bambustudio } } } } }",
-            "variables": {"page": %1%}
-		} )";
+    const char* query = kind == SupportDataCatalogKind::Printers
+        ? "query GetPrinters($page: Int) { printers(page: $page, pageSize: 20) { pages pageInfo { hasNextPage } objects { ... on Printer  { id name heatedChamber alternativeNames { bambustudio } } } } }"
+        : "query GetMaterias($page: Int) { materials(page: $page, pageSize: 20) { pages pageInfo { hasNextPage } objects { ... on Material  { id name feedstock alternativeNames { bambustudio } } } } }";
 
-    query_body = boost::str(boost::format(query_body) % page);
+    nlohmann::json request_body;
+    request_body["query"] = query;
+    request_body["variables"]["page"] = page;
 
-    std::string url_copy  = helio_api_url;
-    std::string key_copy  = helio_api_key;
-    int         page_copy = page;
+    SupportDataHttpResponse response;
 
-    auto http = Http::post(url_copy);
+    if (stopping.load(std::memory_order_acquire)) {
+        response.error = "Helio support-data request stopped during shutdown";
+        return response;
+    }
 
+    auto http = Http::post(helio_api_url);
     http.header("Content-Type", "application/json")
         .header("Authorization", "Bearer " + helio_api_key)
         .header("HelioAdditive-Client-Name", SLIC3R_APP_NAME)
         .header("HelioAdditive-Client-Version", helio_client_version())
-        .set_post_body(query_body);
-
-    http.timeout_connect(20)
+        .set_post_body(request_body.dump())
+        .timeout_connect(20)
         .timeout_max(100)
-        .on_complete([url_copy, key_copy, page_copy, retries_left](std::string body, unsigned status) {
-            BOOST_LOG_TRIVIAL(info) << "request_support_material" << body;
-            nlohmann::json                         parsed_obj = nlohmann::json::parse(body);
-            std::vector<HelioQuery::SupportedData> supported_materials;
-
-            try {
-                if (parsed_obj.contains("data") && parsed_obj["data"].contains("materials")) {
-                    auto materials = parsed_obj["data"]["materials"];
-                    if (materials.contains("objects") && materials["objects"].is_array()) {
-                        for (const auto &pobj : materials["objects"]) {
-                            HelioQuery::SupportedData sp;
-                            if (pobj.contains("id") && !pobj["id"].is_null()) { sp.id = pobj["id"].get<std::string>(); }
-                            if (pobj.contains("name") && !pobj["id"].is_null()) { sp.name = pobj["name"].get<std::string>(); }
-                            if (pobj.contains("feedstock") && !pobj["feedstock"].is_null()) { sp.feedstock = pobj["feedstock"].get<std::string>(); }
-                            if (pobj.contains("alternativeNames") && pobj["alternativeNames"].is_object()) {
-                                auto alternativeNames = pobj["alternativeNames"];
-
-                                //bambu materials
-                                if (alternativeNames.contains("bambustudio") && !alternativeNames["bambustudio"].is_null()) {
-                                    sp.native_name = alternativeNames["bambustudio"].get<std::string>();
-                                }
-                                //third party materials
-                                else {
-                                    if (pobj.contains("name") && !pobj["id"].is_null()) { sp.native_name = pobj["name"].get<std::string>(); }
-                                }
-                            }
-                            // Only include materials with feedstock type FILAMENT
-                            if (sp.feedstock == "FILAMENT") {
-                                supported_materials.push_back(sp);
-                            }
-                        }
-                    }
-
-                    HelioQuery::global_supported_materials.insert(HelioQuery::global_supported_materials.end(), supported_materials.begin(), supported_materials.end());
-
-                    if (materials.contains("pageInfo") && materials["pageInfo"].contains("hasNextPage") && materials["pageInfo"]["hasNextPage"].get<bool>()) {
-                        HelioQuery::request_support_material(url_copy, key_copy, page_copy + 1, retries_left);
-                    } else {
-                        HelioQuery::global_materials_fully_loaded = true;
-                        BOOST_LOG_TRIVIAL(info) << "Helio: all material pages loaded, total: " << HelioQuery::global_supported_materials.size();
-                    }
-                }
-            } catch (const std::exception& e) {
-                BOOST_LOG_TRIVIAL(error) << "Helio request_support_material (page " << page_copy << ", retries=" << retries_left << "): " << e.what();
-                if (retries_left > 0) {
-                    std::this_thread::sleep_for(std::chrono::seconds(2));
-                    HelioQuery::request_support_material(url_copy, key_copy, page_copy, retries_left - 1);
-                } else {
-                    HelioQuery::global_materials_fully_loaded = true;
-                }
-            } catch (...) {
-                BOOST_LOG_TRIVIAL(error) << "Helio request_support_material (page " << page_copy << ", retries=" << retries_left << "): unknown error";
-                if (retries_left > 0) {
-                    std::this_thread::sleep_for(std::chrono::seconds(2));
-                    HelioQuery::request_support_material(url_copy, key_copy, page_copy, retries_left - 1);
-                } else {
-                    HelioQuery::global_materials_fully_loaded = true;
-                }
-            }
+        .on_complete([&response](std::string body, unsigned status) {
+            response.status = status;
+            response.body   = std::move(body);
         })
-        .on_error([url_copy, key_copy, page_copy, retries_left](std::string body, std::string error, unsigned status) {
-            BOOST_LOG_TRIVIAL(error) << "request_support_material error (page " << page_copy << ", retries=" << retries_left << "): " << error << ", status: " << status << ", body: " << body;
-            if (retries_left > 0) {
-                std::this_thread::sleep_for(std::chrono::seconds(2));
-                HelioQuery::request_support_material(url_copy, key_copy, page_copy, retries_left - 1);
-            } else {
-                HelioQuery::global_materials_fully_loaded = true;
-            }
+        .on_error([&response](std::string body, std::string error, unsigned status) {
+            response.status = status;
+            response.body   = std::move(body);
+            response.error  = std::move(error);
         })
-        .perform();
+        .perform_sync();
+
+    return response;
+}
+
+SupportDataCatalogStore& helio_printers_store()
+{
+    static SupportDataCatalogStore* store =
+        new SupportDataCatalogStore(SupportDataCatalogKind::Printers);
+    return *store;
+}
+
+SupportDataCatalogStore& helio_materials_store()
+{
+    static SupportDataCatalogStore* store =
+        new SupportDataCatalogStore(SupportDataCatalogKind::Materials);
+    return *store;
+}
+
+bool helio_request_support_data(SupportDataCatalogStore& store,
+                                const std::string& helio_api_url,
+                                const std::string& helio_api_key,
+                                bool force_refresh)
+{
+    if (!store.try_begin(force_refresh)) {
+        return false;
+    }
+
+    const bool worker_started = helio_request_workers().start(
+        [&store, helio_api_url, helio_api_key](const std::atomic_bool& stopping) {
+            store.run(
+                [&helio_api_url, &helio_api_key, &stopping](SupportDataCatalogKind kind, int page) {
+                    return helio_fetch_support_data_page(kind, helio_api_url, helio_api_key, page, stopping);
+                },
+                [&stopping](int seconds) {
+                    for (int elapsed = 0;
+                         elapsed < seconds * 10 && !stopping.load(std::memory_order_acquire);
+                         ++elapsed) {
+                        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+                    }
+                },
+                [](const SupportDataLoadAttempt& attempt) {
+                    const char* catalog = attempt.kind == SupportDataCatalogKind::Printers ? "printers" : "materials";
+                    BOOST_LOG_TRIVIAL(warning) << "Helio support-data load: catalog=" << catalog
+                        << ", page=" << attempt.page
+                        << ", retry-kind=" << helio_retry_kind_name(attempt.retry_kind)
+                        << ", attempt=" << attempt.attempt << "/" << attempt.max_attempts
+                        << ", status=" << attempt.status
+                        << ", trace-id=" << attempt.trace_id
+                        << ", error=" << attempt.error;
+                });
+        });
+
+    if (!worker_started) {
+        store.run([](SupportDataCatalogKind, int) {
+            SupportDataHttpResponse response;
+            response.error = "Failed to start Helio support-data worker";
+            return response;
+        });
+        return false;
+    }
+    return true;
+}
+
+} // anonymous namespace
+
+bool HelioQuery::request_all_support_machine(const std::string& helio_api_url,
+                                             const std::string& helio_api_key,
+                                             bool force_refresh)
+{
+    return helio_request_support_data(helio_printers_store(), helio_api_url, helio_api_key, force_refresh);
+}
+
+bool HelioQuery::request_all_support_materials(const std::string& helio_api_url,
+                                               const std::string& helio_api_key,
+                                               bool force_refresh)
+{
+    return helio_request_support_data(helio_materials_store(), helio_api_url, helio_api_key, force_refresh);
+}
+
+HelioQuery::SupportDataSnapshot HelioQuery::supported_printers_snapshot()
+{
+    return helio_printers_store().snapshot();
+}
+
+HelioQuery::SupportDataSnapshot HelioQuery::supported_materials_snapshot()
+{
+    return helio_materials_store().snapshot();
+}
+
+SupportDataLoadState HelioQuery::supported_printers_state()
+{
+    return helio_printers_store().state();
+}
+
+SupportDataLoadState HelioQuery::supported_materials_state()
+{
+    return helio_materials_store().state();
+}
+
+std::string HelioQuery::supported_printers_last_error()
+{
+    return helio_printers_store().last_error();
+}
+
+std::string HelioQuery::supported_materials_last_error()
+{
+    return helio_materials_store().last_error();
+}
+
+SupportDataAvailability HelioQuery::supported_data_availability()
+{
+    return Slic3r::support_data_availability(helio_printers_store().view(), helio_materials_store().view());
+}
+
+void HelioQuery::shutdown_background_requests()
+{
+    helio_request_workers().shutdown();
 }
 
 void HelioQuery::request_print_priority_options(

--- a/src/slic3r/Utils/HelioDragon.hpp
+++ b/src/slic3r/Utils/HelioDragon.hpp
@@ -297,6 +297,7 @@ public:
     static std::string          supported_printers_last_error();
     static std::string          supported_materials_last_error();
     static SupportDataAvailability supported_data_availability();
+    static bool                 has_pending_support_data_refresh();
     static void                 shutdown_background_requests();
     static void request_pat_token(std::function<void(std::string)> func);
     static void optimization_feedback(const std::string helio_api_url, const std::string helio_api_key, std::string optimization_id, float rating, std::string comment);

--- a/src/slic3r/Utils/HelioDragon.hpp
+++ b/src/slic3r/Utils/HelioDragon.hpp
@@ -337,6 +337,13 @@ public:
 
     static void clear_print_priority_cache();
 
+    // Monotonic counter bumped whenever the stored Helio PAT changes. Account-scoped
+    // requests capture it before they start and drop their result if it no longer
+    // matches, so a response fetched with the previous account's credentials can never
+    // repopulate a cache that was cleared on the credential change.
+    static std::uint64_t credential_generation();
+    static void          bump_credential_generation();
+
     /*for helio simulation*/
     static CreateSimulationResult create_simulation(const std::string  helio_api_url,
                                                     const std::string  helio_api_key,

--- a/src/slic3r/Utils/HelioDragon.hpp
+++ b/src/slic3r/Utils/HelioDragon.hpp
@@ -347,6 +347,11 @@ public:
     // so an in-flight response can never land between the two.
     static void invalidate_account_scoped_caches();
 
+    // Call when the Helio endpoint changes without the PAT being re-set (region switch):
+    // drops the account-scoped caches and both catalog snapshots so the next request
+    // reloads from the newly selected endpoint.
+    static void invalidate_support_data_for_endpoint_change();
+
     /*for helio simulation*/
     static CreateSimulationResult create_simulation(const std::string  helio_api_url,
                                                     const std::string  helio_api_key,

--- a/src/slic3r/Utils/HelioDragon.hpp
+++ b/src/slic3r/Utils/HelioDragon.hpp
@@ -17,6 +17,7 @@
 #include <utility>
 
 #include "PrintHost.hpp"
+#include "HelioSupportData.hpp"
 #include "libslic3r/PrintConfig.hpp"
 #include "nlohmann/json.hpp"
 #include "../GUI/BackgroundSlicingProcess.hpp"
@@ -85,14 +86,8 @@ public:
         std::string trace_id;
     };
 
-    struct SupportedData
-    {
-        std::string id;
-        std::string name;
-        std::string native_name;
-        std::string feedstock;
-        bool heated_chamber{false};
-    };
+    using SupportedData = HelioSupportedData;
+    using SupportDataSnapshot = std::shared_ptr<const std::vector<SupportedData>>;
 
     struct PrintPriorityOption {
         std::string value;        // Enum value: "SPEED_AND_STRENGTH"
@@ -288,8 +283,21 @@ public:
     static std::string get_helio_api_url();
     static std::string get_helio_pat();
     static void set_helio_pat(std::string pat);
-    static void request_support_machine(const std::string helio_api_url, const std::string helio_api_key, int page, int retries_left = 3);
-    static void request_support_material(const std::string helio_api_url, const std::string helio_api_key, int page, int retries_left = 3);
+    static bool request_all_support_machine(const std::string& helio_api_url,
+                                            const std::string& helio_api_key,
+                                            bool force_refresh = false);
+    static bool request_all_support_materials(const std::string& helio_api_url,
+                                              const std::string& helio_api_key,
+                                              bool force_refresh = false);
+
+    static SupportDataSnapshot  supported_printers_snapshot();
+    static SupportDataSnapshot  supported_materials_snapshot();
+    static SupportDataLoadState supported_printers_state();
+    static SupportDataLoadState supported_materials_state();
+    static std::string          supported_printers_last_error();
+    static std::string          supported_materials_last_error();
+    static SupportDataAvailability supported_data_availability();
+    static void                 shutdown_background_requests();
     static void request_pat_token(std::function<void(std::string)> func);
     static void optimization_feedback(const std::string helio_api_url, const std::string helio_api_key, std::string optimization_id, float rating, std::string comment);
     static PresignedURLResult create_presigned_url(const std::string helio_api_url, const std::string helio_api_key);
@@ -314,21 +322,6 @@ public:
                                               const std::vector<MaterialInput>& materials,
                                               bool isMultiColor, bool isMultiMaterial);
 
-    static void request_all_support_machine(const std::string helio_api_url, const std::string helio_api_key)
-    {
-        global_printers_fully_loaded = false;
-        global_supported_printers.clear();
-        clear_print_priority_cache();
-        request_support_machine(helio_api_url, helio_api_key, 1);
-    }
-
-    static void request_all_support_materials(const std::string helio_api_url, const std::string helio_api_key)
-    {
-        global_materials_fully_loaded = false;
-        global_supported_materials.clear();
-        clear_print_priority_cache();
-        request_support_material(helio_api_url, helio_api_key, 1);
-    }
 
     static void request_print_priority_options(
         const std::string& helio_api_url,
@@ -411,10 +404,6 @@ public:
         return "OrcaSlicer " + iso_datetime;
     }
 
-    static std::vector<SupportedData> global_supported_printers;
-    static std::vector<SupportedData> global_supported_materials;
-    static bool global_printers_fully_loaded;
-    static bool global_materials_fully_loaded;
     static std::map<std::string, std::vector<PrintPriorityOption>> global_print_priority_cache;
     static std::string last_simulation_trace_id;
     static std::string last_optimization_trace_id;

--- a/src/slic3r/Utils/HelioDragon.hpp
+++ b/src/slic3r/Utils/HelioDragon.hpp
@@ -342,7 +342,10 @@ public:
     // matches, so a response fetched with the previous account's credentials can never
     // repopulate a cache that was cleared on the credential change.
     static std::uint64_t credential_generation();
-    static void          bump_credential_generation();
+
+    // Bumps the credential generation and clears the print-priority cache atomically,
+    // so an in-flight response can never land between the two.
+    static void invalidate_account_scoped_caches();
 
     /*for helio simulation*/
     static CreateSimulationResult create_simulation(const std::string  helio_api_url,

--- a/src/slic3r/Utils/HelioRetryPolicy.cpp
+++ b/src/slic3r/Utils/HelioRetryPolicy.cpp
@@ -130,7 +130,7 @@ HelioRetryKind helio_classify_graphql_response(unsigned status, const nlohmann::
 
 HelioRetryKind helio_classify_graphql_response(unsigned status, const std::string& body)
 {
-    if (helio_is_terminal_http_status(status) || status != 200) {
+    if (status != 200) {
         return HelioRetryKind::None;
     }
 
@@ -155,8 +155,9 @@ HelioRetryKind helio_classify_retry(unsigned status,
         return HelioRetryKind::Transient;
     }
 
-    (void) body;
-    (void) transport_error;
+    if (helio_is_transient_error_message(body) || helio_is_transient_error_message(transport_error)) {
+        return HelioRetryKind::Transient;
+    }
     return HelioRetryKind::None;
 }
 

--- a/src/slic3r/Utils/HelioRetryPolicy.cpp
+++ b/src/slic3r/Utils/HelioRetryPolicy.cpp
@@ -1,0 +1,203 @@
+#include "HelioRetryPolicy.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <vector>
+
+#include "nlohmann/json.hpp"
+
+namespace Slic3r {
+
+namespace {
+
+std::string helio_lower_copy(const std::string& value)
+{
+    std::string lowered;
+    lowered.reserve(value.size());
+    for (unsigned char c : value) {
+        lowered += static_cast<char>(std::tolower(c));
+    }
+    return lowered;
+}
+
+bool helio_error_object_has_exact_backend_auth_error(const nlohmann::json& error)
+{
+    return error.is_object() && error.contains("message") && error["message"].is_string() &&
+           error["message"].get<std::string>() == HELIO_BACKEND_AUTH_401_MESSAGE;
+}
+
+bool helio_error_object_has_message(const nlohmann::json& error)
+{
+    return error.is_object() && error.contains("message") && error["message"].is_string();
+}
+
+bool helio_graphql_errors_have_transient_message(const nlohmann::json& errors)
+{
+    const auto has_transient_message = [](const nlohmann::json& error) {
+        return error.is_object() && error.contains("message") && error["message"].is_string() &&
+               helio_is_transient_error_message(error["message"].get<std::string>());
+    };
+
+    if (errors.is_array()) {
+        return std::any_of(errors.begin(), errors.end(), has_transient_message);
+    }
+    return has_transient_message(errors);
+}
+
+} // namespace
+
+bool helio_is_terminal_http_status(unsigned status) noexcept
+{
+    return status == 401 || status == 403 || status == 404;
+}
+
+bool helio_is_transient_http_status(unsigned status) noexcept
+{
+    return status == 0 || status == 408 || status == 425 || status == 429 || status >= 500;
+}
+
+bool helio_is_transient_error_message(const std::string& message)
+{
+    const std::string lower = helio_lower_copy(message);
+    static const std::vector<std::string> transient_markers = {
+        "temporar",
+        "timeout",
+        "timed out",
+        "try again",
+        "rate limit",
+        "too many requests",
+        "network",
+        "connection",
+        "disconnect",
+        "reset by peer",
+        "econn",
+        "unavailable",
+        "gateway",
+        "service unavailable",
+        "internal server",
+        "deadline",
+        "overloaded"
+    };
+
+    return std::any_of(transient_markers.begin(), transient_markers.end(), [&lower](const std::string& marker) {
+        return lower.find(marker) != std::string::npos;
+    });
+}
+
+bool helio_has_graphql_errors(const nlohmann::json& response)
+{
+    if (!response.is_object() || !response.contains("errors")) {
+        return false;
+    }
+
+    const nlohmann::json& errors = response["errors"];
+    if (errors.is_array()) {
+        return std::any_of(errors.begin(), errors.end(), helio_error_object_has_message);
+    }
+    return helio_error_object_has_message(errors);
+}
+
+bool helio_has_exact_backend_auth_error(const nlohmann::json& response)
+{
+    if (!helio_has_graphql_errors(response)) {
+        return false;
+    }
+
+    const nlohmann::json& errors = response["errors"];
+    if (errors.is_array()) {
+        return std::any_of(errors.begin(), errors.end(), helio_error_object_has_exact_backend_auth_error);
+    }
+    return helio_error_object_has_exact_backend_auth_error(errors);
+}
+
+HelioRetryKind helio_classify_graphql_response(unsigned status, const nlohmann::json& response)
+{
+    if (status != 200 || !response.is_object() || !response.contains("errors")) {
+        return HelioRetryKind::None;
+    }
+
+    if (!helio_has_graphql_errors(response)) {
+        return HelioRetryKind::Transient;
+    }
+
+    if (helio_has_exact_backend_auth_error(response)) {
+        return HelioRetryKind::BackendAuth;
+    }
+
+    return helio_graphql_errors_have_transient_message(response["errors"]) ? HelioRetryKind::Transient :
+                                                                             HelioRetryKind::None;
+}
+
+HelioRetryKind helio_classify_graphql_response(unsigned status, const std::string& body)
+{
+    if (helio_is_terminal_http_status(status) || status != 200) {
+        return HelioRetryKind::None;
+    }
+
+    try {
+        return helio_classify_graphql_response(status, nlohmann::json::parse(body));
+    } catch (...) {
+        return HelioRetryKind::Transient;
+    }
+}
+
+HelioRetryKind helio_classify_retry(unsigned status,
+                                    const std::string& body,
+                                    const std::string& transport_error)
+{
+    if (helio_is_terminal_http_status(status)) {
+        return HelioRetryKind::None;
+    }
+    if (status == 200) {
+        return helio_classify_graphql_response(status, body);
+    }
+    if (helio_is_transient_http_status(status)) {
+        return HelioRetryKind::Transient;
+    }
+
+    (void) body;
+    (void) transport_error;
+    return HelioRetryKind::None;
+}
+
+const char* helio_retry_kind_name(HelioRetryKind kind) noexcept
+{
+    switch (kind) {
+    case HelioRetryKind::None:        return "none";
+    case HelioRetryKind::Transient:   return "transient";
+    case HelioRetryKind::BackendAuth: return "backend-auth";
+    }
+    return "unknown";
+}
+
+HelioRetryController::HelioRetryController(unsigned max_consecutive_backend_auth_retries) noexcept
+    : m_max_consecutive_backend_auth_retries(max_consecutive_backend_auth_retries)
+{}
+
+bool HelioRetryController::should_retry(HelioRetryKind kind) noexcept
+{
+    if (kind == HelioRetryKind::BackendAuth) {
+        ++m_consecutive_backend_auth_failures;
+        return m_consecutive_backend_auth_failures <= m_max_consecutive_backend_auth_retries;
+    }
+
+    m_consecutive_backend_auth_failures = 0;
+    return kind == HelioRetryKind::Transient;
+}
+
+void HelioRetryController::reset() noexcept
+{
+    m_consecutive_backend_auth_failures = 0;
+}
+
+unsigned HelioRetryController::consecutive_backend_auth_failures() const noexcept
+{
+    return m_consecutive_backend_auth_failures;
+}
+
+unsigned HelioRetryController::max_consecutive_backend_auth_retries() const noexcept
+{
+    return m_max_consecutive_backend_auth_retries;
+}
+
+} // namespace Slic3r

--- a/src/slic3r/Utils/HelioRetryPolicy.hpp
+++ b/src/slic3r/Utils/HelioRetryPolicy.hpp
@@ -1,5 +1,4 @@
-#ifndef slic3r_HelioRetryPolicy_hpp_
-#define slic3r_HelioRetryPolicy_hpp_
+#pragma once
 
 #include <string>
 
@@ -50,5 +49,3 @@ private:
 };
 
 } // namespace Slic3r
-
-#endif // slic3r_HelioRetryPolicy_hpp_

--- a/src/slic3r/Utils/HelioRetryPolicy.hpp
+++ b/src/slic3r/Utils/HelioRetryPolicy.hpp
@@ -1,0 +1,54 @@
+#ifndef slic3r_HelioRetryPolicy_hpp_
+#define slic3r_HelioRetryPolicy_hpp_
+
+#include <string>
+
+#include "nlohmann/json_fwd.hpp"
+
+namespace Slic3r {
+
+enum class HelioRetryKind
+{
+    None,
+    Transient,
+    BackendAuth
+};
+
+inline constexpr const char HELIO_BACKEND_AUTH_401_MESSAGE[] =
+    "Authentication failed: Auth service returned status 401";
+
+bool helio_is_terminal_http_status(unsigned status) noexcept;
+bool helio_is_transient_http_status(unsigned status) noexcept;
+bool helio_is_transient_error_message(const std::string& message);
+
+bool helio_has_graphql_errors(const nlohmann::json& response);
+bool helio_has_exact_backend_auth_error(const nlohmann::json& response);
+
+HelioRetryKind helio_classify_graphql_response(unsigned status, const nlohmann::json& response);
+HelioRetryKind helio_classify_graphql_response(unsigned status, const std::string& body);
+
+HelioRetryKind helio_classify_retry(unsigned status,
+                                    const std::string& body = std::string(),
+                                    const std::string& transport_error = std::string());
+
+const char* helio_retry_kind_name(HelioRetryKind kind) noexcept;
+
+class HelioRetryController
+{
+public:
+    explicit HelioRetryController(unsigned max_consecutive_backend_auth_retries = 1) noexcept;
+
+    bool should_retry(HelioRetryKind kind) noexcept;
+    void reset() noexcept;
+
+    unsigned consecutive_backend_auth_failures() const noexcept;
+    unsigned max_consecutive_backend_auth_retries() const noexcept;
+
+private:
+    unsigned m_consecutive_backend_auth_failures{0};
+    unsigned m_max_consecutive_backend_auth_retries{1};
+};
+
+} // namespace Slic3r
+
+#endif // slic3r_HelioRetryPolicy_hpp_

--- a/src/slic3r/Utils/HelioSupportData.cpp
+++ b/src/slic3r/Utils/HelioSupportData.cpp
@@ -378,6 +378,15 @@ bool SupportDataCatalogStore::run_impl(const PageFetcher&   fetcher,
         HelioRetryController  retry_controller;
 
         for (int attempt = 1; attempt <= MAX_ATTEMPTS_PER_PAGE; ++attempt) {
+            // Re-checked per attempt (not just per page): with up to 4 attempts and a
+            // 100s HTTP timeout, a revoked run would otherwise keep issuing requests
+            // under the old credential for minutes after a logout. The retry wait
+            // happens at the end of the previous iteration, so this also covers the
+            // "invalidated while sleeping" case.
+            if (!is_run_current(run_generation)) {
+                return false;
+            }
+
             SupportDataHttpResponse response;
             try {
                 response = fetcher(m_kind, page);

--- a/src/slic3r/Utils/HelioSupportData.cpp
+++ b/src/slic3r/Utils/HelioSupportData.cpp
@@ -1,0 +1,441 @@
+#include "HelioSupportData.hpp"
+
+#include "nlohmann/json.hpp"
+
+#include <exception>
+#include <iterator>
+#include <sstream>
+#include <utility>
+
+namespace Slic3r {
+
+namespace {
+
+using json = nlohmann::json;
+
+std::string catalog_name(SupportDataCatalogKind kind)
+{
+    return kind == SupportDataCatalogKind::Printers ? "printers" : "materials";
+}
+
+std::string http_error(const SupportDataHttpResponse& response)
+{
+    if (!response.error.empty()) {
+        return response.error;
+    }
+
+    std::ostringstream message;
+    message << "HTTP status: " << response.status;
+    if (!response.body.empty()) {
+        message << ", body: " << response.body;
+    }
+    return message.str();
+}
+
+std::string graphql_error(const json& response)
+{
+    if (!response.contains("errors")) {
+        return {};
+    }
+
+    const json& errors = response["errors"];
+    std::ostringstream message;
+
+    if (errors.is_array()) {
+        bool first = true;
+        for (const json& error : errors) {
+            if (!error.is_object() || !error.contains("message") || !error["message"].is_string()) {
+                continue;
+            }
+            if (!first) {
+                message << '\n';
+            }
+            message << error["message"].get<std::string>();
+            first = false;
+        }
+    } else if (errors.is_object() && errors.contains("message") && errors["message"].is_string()) {
+        message << errors["message"].get<std::string>();
+    }
+
+    const std::string result = message.str();
+    return result.empty() ? errors.dump() : result;
+}
+
+SupportDataPageResult failed_page(const SupportDataHttpResponse& response,
+                                  HelioRetryKind                 retry_kind,
+                                  std::string                    error)
+{
+    SupportDataPageResult result;
+    result.status     = response.status;
+    result.retry_kind = retry_kind;
+    result.error      = std::move(error);
+    result.trace_id   = response.trace_id;
+    return result;
+}
+
+SupportDataPageResult incomplete_page(const SupportDataHttpResponse& response, std::string error)
+{
+    return failed_page(response, HelioRetryKind::Transient, std::move(error));
+}
+
+bool required_string(const json& object, const char* key, std::string& value)
+{
+    if (!object.contains(key) || !object[key].is_string()) {
+        return false;
+    }
+    value = object[key].get<std::string>();
+    return !value.empty();
+}
+
+void log_attempt(const SupportDataCatalogStore::Logger& logger, const SupportDataLoadAttempt& attempt) noexcept
+{
+    if (!logger) {
+        return;
+    }
+    try {
+        logger(attempt);
+    } catch (...) {
+    }
+}
+
+} // namespace
+
+SupportDataPageResult parse_support_data_page(SupportDataCatalogKind        kind,
+                                              int                           page,
+                                              const SupportDataHttpResponse& response)
+{
+    const HelioRetryKind response_retry_kind = helio_classify_retry(response.status, response.body, response.error);
+
+    if (response.status != 200) {
+        return failed_page(response, response_retry_kind, http_error(response));
+    }
+
+    json parsed;
+    try {
+        parsed = json::parse(response.body);
+    } catch (const std::exception& e) {
+        return incomplete_page(response, std::string("Malformed Helio support-data response: ") + e.what());
+    } catch (...) {
+        return incomplete_page(response, "Malformed Helio support-data response");
+    }
+
+    if (helio_has_graphql_errors(parsed)) {
+        return failed_page(response, response_retry_kind, graphql_error(parsed));
+    }
+
+    const std::string payload_name = catalog_name(kind);
+    if (!parsed.contains("data") || !parsed["data"].is_object() ||
+        !parsed["data"].contains(payload_name) || !parsed["data"][payload_name].is_object()) {
+        return incomplete_page(response, "Helio support-data response is missing data." + payload_name);
+    }
+
+    const json& payload = parsed["data"][payload_name];
+    if (!payload.contains("pages") || !payload["pages"].is_number_integer() ||
+        !payload.contains("pageInfo") || !payload["pageInfo"].is_object() ||
+        !payload["pageInfo"].contains("hasNextPage") || !payload["pageInfo"]["hasNextPage"].is_boolean() ||
+        !payload.contains("objects") || !payload["objects"].is_array()) {
+        return incomplete_page(response, "Helio " + payload_name + " page metadata is incomplete");
+    }
+
+    int  total_pages = 0;
+    bool has_next_page = false;
+    try {
+        total_pages   = payload["pages"].get<int>();
+        has_next_page = payload["pageInfo"]["hasNextPage"].get<bool>();
+    } catch (const std::exception& e) {
+        return incomplete_page(response, std::string("Helio ") + payload_name + " pagination metadata is invalid: " + e.what());
+    } catch (...) {
+        return incomplete_page(response, "Helio " + payload_name + " pagination metadata is invalid");
+    }
+    const json& objects = payload["objects"];
+
+    if (page < 1 || total_pages < 1 || page > total_pages || objects.empty()) {
+        return incomplete_page(response, "Helio " + payload_name + " page is empty or out of range");
+    }
+    if ((has_next_page && page >= total_pages) || (!has_next_page && page < total_pages)) {
+        return incomplete_page(response, "Helio " + payload_name + " pagination metadata is inconsistent");
+    }
+
+    SupportDataPageResult result;
+    result.status        = response.status;
+    result.trace_id      = response.trace_id;
+    result.total_pages   = total_pages;
+    result.has_next_page = has_next_page;
+
+    try {
+        for (const json& object : objects) {
+            if (!object.is_object()) {
+                return incomplete_page(response, "Helio " + payload_name + " page contains an invalid object");
+            }
+
+            HelioSupportedData item;
+            if (!required_string(object, "id", item.id) || !required_string(object, "name", item.name)) {
+                return incomplete_page(response, "Helio " + payload_name + " page contains an incomplete object");
+            }
+
+            if (kind == SupportDataCatalogKind::Printers) {
+                if (object.contains("heatedChamber")) {
+                    if (!object["heatedChamber"].is_boolean()) {
+                        return incomplete_page(response, "Helio printers page contains an invalid heatedChamber value");
+                    }
+                    item.heated_chamber = object["heatedChamber"].get<bool>();
+                }
+            } else {
+                if (!required_string(object, "feedstock", item.feedstock)) {
+                    return incomplete_page(response, "Helio materials page contains an incomplete feedstock value");
+                }
+            }
+
+            if (object.contains("alternativeNames") && !object["alternativeNames"].is_null()) {
+                if (!object["alternativeNames"].is_object()) {
+                    return incomplete_page(response, "Helio " + payload_name + " page contains invalid alternativeNames");
+                }
+                const json& alternative_names = object["alternativeNames"];
+                if (alternative_names.contains("bambustudio") && !alternative_names["bambustudio"].is_null()) {
+                    if (!alternative_names["bambustudio"].is_string()) {
+                        return incomplete_page(response, "Helio " + payload_name + " page contains an invalid Bambu Studio name");
+                    }
+                    item.native_name = alternative_names["bambustudio"].get<std::string>();
+                }
+            }
+
+            if (kind == SupportDataCatalogKind::Materials && item.native_name.empty()) {
+                item.native_name = item.name;
+            }
+
+            if (kind == SupportDataCatalogKind::Printers || item.feedstock == "FILAMENT") {
+                result.items.push_back(std::move(item));
+            }
+        }
+    } catch (const std::exception& e) {
+        return incomplete_page(response, std::string("Failed to parse Helio ") + payload_name + " page: " + e.what());
+    } catch (...) {
+        return incomplete_page(response, "Failed to parse Helio " + payload_name + " page");
+    }
+
+    result.success    = true;
+    result.retry_kind = HelioRetryKind::None;
+    return result;
+}
+
+SupportDataAvailability support_data_availability(const SupportDataCatalogView& printers,
+                                                  const SupportDataCatalogView& materials) noexcept
+{
+    if (printers.has_usable_snapshot() && materials.has_usable_snapshot()) {
+        return SupportDataAvailability::Usable;
+    }
+
+    if ((!printers.has_usable_snapshot() && printers.state == SupportDataLoadState::Failed) ||
+        (!materials.has_usable_snapshot() && materials.state == SupportDataLoadState::Failed)) {
+        return SupportDataAvailability::LoadFailed;
+    }
+
+    if ((!printers.has_usable_snapshot() &&
+         (printers.state == SupportDataLoadState::NotLoaded || printers.state == SupportDataLoadState::Loading)) ||
+        (!materials.has_usable_snapshot() &&
+         (materials.state == SupportDataLoadState::NotLoaded || materials.state == SupportDataLoadState::Loading))) {
+        return SupportDataAvailability::Synchronizing;
+    }
+
+    return SupportDataAvailability::LoadFailed;
+}
+
+SupportDataCatalogStore::SupportDataCatalogStore(SupportDataCatalogKind kind)
+    : m_kind(kind)
+{}
+
+bool SupportDataCatalogStore::try_begin(bool force_refresh)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    if (m_state == SupportDataLoadState::Loading) {
+        return false;
+    }
+    if (m_snapshot && !force_refresh) {
+        return false;
+    }
+    if (m_state == SupportDataLoadState::Ready && !force_refresh) {
+        return false;
+    }
+
+    m_state       = SupportDataLoadState::Loading;
+    m_last_error.clear();
+    m_run_claimed = false;
+    return true;
+}
+
+bool SupportDataCatalogStore::claim_run()
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    if (m_state != SupportDataLoadState::Loading || m_run_claimed) {
+        return false;
+    }
+    m_run_claimed = true;
+    return true;
+}
+
+bool SupportDataCatalogStore::run(const PageFetcher&   fetcher,
+                                  const RetrySleeper& sleeper,
+                                  const Logger&       logger)
+{
+    if (!claim_run()) {
+        return false;
+    }
+
+    try {
+        return run_impl(fetcher, sleeper, logger);
+    } catch (const std::exception& e) {
+        fail(std::string("Helio support-data load failed: ") + e.what());
+    } catch (...) {
+        fail("Helio support-data load failed");
+    }
+    return false;
+}
+
+bool SupportDataCatalogStore::run_impl(const PageFetcher&   fetcher,
+                                       const RetrySleeper& sleeper,
+                                       const Logger&       logger)
+{
+    if (!fetcher) {
+        fail("No Helio support-data page fetcher was provided");
+        return false;
+    }
+
+    std::vector<HelioSupportedData> staging;
+    int                             page = 1;
+    int                             expected_total_pages = 0;
+
+    while (true) {
+        SupportDataPageResult page_result;
+        bool                  page_loaded = false;
+        HelioRetryController  retry_controller;
+
+        for (int attempt = 1; attempt <= MAX_ATTEMPTS_PER_PAGE; ++attempt) {
+            SupportDataHttpResponse response;
+            try {
+                response = fetcher(m_kind, page);
+            } catch (const std::exception& e) {
+                response.error = std::string("Helio support-data fetch failed: ") + e.what();
+            } catch (...) {
+                response.error = "Helio support-data fetch failed";
+            }
+
+            page_result = parse_support_data_page(m_kind, page, response);
+            if (page_result.success && expected_total_pages != 0 &&
+                page_result.total_pages != expected_total_pages) {
+                page_result.success = false;
+                page_result.retry_kind = HelioRetryKind::Transient;
+                page_result.error = "Helio support-data total page count changed during pagination";
+            }
+            if (page_result.success) {
+                page_loaded = true;
+                break;
+            }
+
+            const bool will_retry = attempt < MAX_ATTEMPTS_PER_PAGE &&
+                                    retry_controller.should_retry(page_result.retry_kind);
+            SupportDataLoadAttempt log_entry;
+            log_entry.kind         = m_kind;
+            log_entry.page         = page;
+            log_entry.attempt      = attempt;
+            log_entry.max_attempts = MAX_ATTEMPTS_PER_PAGE;
+            log_entry.status       = page_result.status;
+            log_entry.retry_kind   = page_result.retry_kind;
+            log_entry.will_retry   = will_retry;
+            log_entry.error        = page_result.error;
+            log_entry.trace_id     = page_result.trace_id;
+            log_attempt(logger, log_entry);
+
+            if (!will_retry) {
+                break;
+            }
+
+            if (sleeper) {
+                try {
+                    sleeper(attempt * 2);
+                } catch (const std::exception& e) {
+                    page_result.error = std::string("Helio support-data retry wait failed: ") + e.what();
+                    break;
+                } catch (...) {
+                    page_result.error = "Helio support-data retry wait failed";
+                    break;
+                }
+            }
+        }
+
+        if (!page_loaded) {
+            fail(page_result.error.empty() ? "Helio support-data request failed" : std::move(page_result.error));
+            return false;
+        }
+
+        if (expected_total_pages == 0) {
+            expected_total_pages = page_result.total_pages;
+        }
+        staging.insert(staging.end(),
+                       std::make_move_iterator(page_result.items.begin()),
+                       std::make_move_iterator(page_result.items.end()));
+
+        if (!page_result.has_next_page) {
+            break;
+        }
+        ++page;
+    }
+
+    if (staging.empty()) {
+        fail("Helio support-data response contained no supported entries");
+        return false;
+    }
+
+    publish(std::move(staging));
+    return true;
+}
+
+void SupportDataCatalogStore::publish(std::vector<HelioSupportedData>&& complete_snapshot)
+{
+    auto snapshot = std::make_shared<const std::vector<HelioSupportedData>>(std::move(complete_snapshot));
+
+    std::lock_guard<std::mutex> lock(m_mutex);
+    m_snapshot    = std::move(snapshot);
+    m_state       = SupportDataLoadState::Ready;
+    m_last_error.clear();
+    m_run_claimed = false;
+}
+
+void SupportDataCatalogStore::fail(std::string error)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    m_state       = SupportDataLoadState::Failed;
+    m_last_error  = std::move(error);
+    m_run_claimed = false;
+}
+
+SupportDataLoadState SupportDataCatalogStore::state() const
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return m_state;
+}
+
+SupportDataCatalogStore::Snapshot SupportDataCatalogStore::snapshot() const
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return m_snapshot;
+}
+
+std::string SupportDataCatalogStore::last_error() const
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return m_last_error;
+}
+
+bool SupportDataCatalogStore::has_usable_snapshot() const
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return m_snapshot && !m_snapshot->empty();
+}
+
+SupportDataCatalogView SupportDataCatalogStore::view() const
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return {m_state, m_snapshot, m_last_error};
+}
+
+} // namespace Slic3r

--- a/src/slic3r/Utils/HelioSupportData.cpp
+++ b/src/slic3r/Utils/HelioSupportData.cpp
@@ -365,6 +365,7 @@ bool SupportDataCatalogStore::run_impl(const PageFetcher&   fetcher,
     std::vector<HelioSupportedData> staging;
     int                             page = 1;
     int                             expected_total_pages = 0;
+    int                             restarts_remaining = MAX_PAGINATION_RESTARTS;
 
     while (true) {
         // The credentials this run started with may have been revoked (PAT change,
@@ -375,6 +376,7 @@ bool SupportDataCatalogStore::run_impl(const PageFetcher&   fetcher,
 
         SupportDataPageResult page_result;
         bool                  page_loaded = false;
+        bool                  total_pages_changed = false;
         HelioRetryController  retry_controller;
 
         for (int attempt = 1; attempt <= MAX_ATTEMPTS_PER_PAGE; ++attempt) {
@@ -399,9 +401,15 @@ bool SupportDataCatalogStore::run_impl(const PageFetcher&   fetcher,
             page_result = parse_support_data_page(m_kind, page, response);
             if (page_result.success && expected_total_pages != 0 &&
                 page_result.total_pages != expected_total_pages) {
+                // The catalog changed underneath the walk. Retrying *this* page is
+                // futile — every otherwise-valid response would keep failing the same
+                // comparison against the stale expectation until attempts run out.
+                // Restart the walk instead (handled below).
                 page_result.success = false;
                 page_result.retry_kind = HelioRetryKind::Transient;
                 page_result.error = "Helio support-data total page count changed during pagination";
+                total_pages_changed = true;
+                break;
             }
             if (page_result.success) {
                 page_loaded = true;
@@ -437,6 +445,30 @@ bool SupportDataCatalogStore::run_impl(const PageFetcher&   fetcher,
                     break;
                 }
             }
+        }
+
+        if (total_pages_changed) {
+            SupportDataLoadAttempt log_entry;
+            log_entry.kind         = m_kind;
+            log_entry.page         = page;
+            log_entry.attempt      = MAX_PAGINATION_RESTARTS - restarts_remaining + 1;
+            log_entry.max_attempts = MAX_PAGINATION_RESTARTS;
+            log_entry.status       = page_result.status;
+            log_entry.retry_kind   = page_result.retry_kind;
+            log_entry.will_retry   = restarts_remaining > 0;
+            log_entry.error        = page_result.error;
+            log_entry.trace_id     = page_result.trace_id;
+            log_attempt(logger, log_entry);
+
+            if (restarts_remaining <= 0) {
+                fail("Helio support-data total page count kept changing during pagination", run_generation);
+                return false;
+            }
+            --restarts_remaining;
+            staging.clear();
+            page                 = 1;
+            expected_total_pages = 0;
+            continue;
         }
 
         if (!page_loaded) {

--- a/src/slic3r/Utils/HelioSupportData.cpp
+++ b/src/slic3r/Utils/HelioSupportData.cpp
@@ -288,6 +288,33 @@ bool SupportDataCatalogStore::has_pending_refresh() const
     return m_pending_refresh;
 }
 
+bool SupportDataCatalogStore::begin_pending_refresh()
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    if (!m_pending_refresh) {
+        return false;
+    }
+    m_pending_refresh = false;
+    m_state           = SupportDataLoadState::Loading;
+    m_last_error.clear();
+    m_run_claimed     = false;
+    return true;
+}
+
+void SupportDataCatalogStore::invalidate()
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    if (m_state == SupportDataLoadState::Loading) {
+        m_pending_refresh = false;
+        return;
+    }
+    m_snapshot.reset();
+    m_state           = SupportDataLoadState::NotLoaded;
+    m_last_error.clear();
+    m_run_claimed     = false;
+    m_pending_refresh = false;
+}
+
 bool SupportDataCatalogStore::claim_run()
 {
     std::lock_guard<std::mutex> lock(m_mutex);

--- a/src/slic3r/Utils/HelioSupportData.cpp
+++ b/src/slic3r/Utils/HelioSupportData.cpp
@@ -248,6 +248,14 @@ bool SupportDataCatalogStore::try_begin(bool force_refresh)
 {
     std::lock_guard<std::mutex> lock(m_mutex);
     if (m_state == SupportDataLoadState::Loading) {
+        if (force_refresh) {
+            // A load is already in flight (e.g. from Helio startup) and it may be using
+            // stale credentials (e.g. the user just linked/replaced a PAT). Queue a
+            // follow-up refresh instead of discarding this request outright: once the
+            // in-flight run finishes, the caller re-checks consume_pending_refresh() and
+            // re-triggers a fresh load with current credentials.
+            m_pending_refresh = true;
+        }
         return false;
     }
     if (m_snapshot && !force_refresh) {
@@ -257,9 +265,20 @@ bool SupportDataCatalogStore::try_begin(bool force_refresh)
         return false;
     }
 
-    m_state       = SupportDataLoadState::Loading;
+    m_state            = SupportDataLoadState::Loading;
     m_last_error.clear();
-    m_run_claimed = false;
+    m_run_claimed      = false;
+    m_pending_refresh  = false;
+    return true;
+}
+
+bool SupportDataCatalogStore::consume_pending_refresh()
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    if (!m_pending_refresh) {
+        return false;
+    }
+    m_pending_refresh = false;
     return true;
 }
 

--- a/src/slic3r/Utils/HelioSupportData.cpp
+++ b/src/slic3r/Utils/HelioSupportData.cpp
@@ -304,10 +304,11 @@ bool SupportDataCatalogStore::begin_pending_refresh()
 void SupportDataCatalogStore::invalidate()
 {
     std::lock_guard<std::mutex> lock(m_mutex);
-    if (m_state == SupportDataLoadState::Loading) {
-        m_pending_refresh = false;
-        return;
-    }
+    // Bumping the generation revokes any in-flight run: it stops fetching at the next
+    // page boundary, and neither publish() nor fail() will touch the store afterwards.
+    // Without this, a load started with the previous PAT could still publish that
+    // account's catalog, and the next non-forced request would accept it as current.
+    ++m_generation;
     m_snapshot.reset();
     m_state           = SupportDataLoadState::NotLoaded;
     m_last_error.clear();
@@ -315,40 +316,49 @@ void SupportDataCatalogStore::invalidate()
     m_pending_refresh = false;
 }
 
-bool SupportDataCatalogStore::claim_run()
+bool SupportDataCatalogStore::claim_run(std::uint64_t& run_generation)
 {
     std::lock_guard<std::mutex> lock(m_mutex);
     if (m_state != SupportDataLoadState::Loading || m_run_claimed) {
         return false;
     }
-    m_run_claimed = true;
+    m_run_claimed  = true;
+    run_generation = m_generation;
     return true;
+}
+
+bool SupportDataCatalogStore::is_run_current(std::uint64_t run_generation) const
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return run_generation == m_generation;
 }
 
 bool SupportDataCatalogStore::run(const PageFetcher&   fetcher,
                                   const RetrySleeper& sleeper,
                                   const Logger&       logger)
 {
-    if (!claim_run()) {
+    std::uint64_t run_generation = 0;
+    if (!claim_run(run_generation)) {
         return false;
     }
 
     try {
-        return run_impl(fetcher, sleeper, logger);
+        return run_impl(fetcher, sleeper, logger, run_generation);
     } catch (const std::exception& e) {
-        fail(std::string("Helio support-data load failed: ") + e.what());
+        fail(std::string("Helio support-data load failed: ") + e.what(), run_generation);
     } catch (...) {
-        fail("Helio support-data load failed");
+        fail("Helio support-data load failed", run_generation);
     }
     return false;
 }
 
 bool SupportDataCatalogStore::run_impl(const PageFetcher&   fetcher,
                                        const RetrySleeper& sleeper,
-                                       const Logger&       logger)
+                                       const Logger&       logger,
+                                       std::uint64_t       run_generation)
 {
     if (!fetcher) {
-        fail("No Helio support-data page fetcher was provided");
+        fail("No Helio support-data page fetcher was provided", run_generation);
         return false;
     }
 
@@ -357,6 +367,12 @@ bool SupportDataCatalogStore::run_impl(const PageFetcher&   fetcher,
     int                             expected_total_pages = 0;
 
     while (true) {
+        // The credentials this run started with may have been revoked (PAT change,
+        // logout, Helio disabled). Stop before spending another page request.
+        if (!is_run_current(run_generation)) {
+            return false;
+        }
+
         SupportDataPageResult page_result;
         bool                  page_loaded = false;
         HelioRetryController  retry_controller;
@@ -415,7 +431,8 @@ bool SupportDataCatalogStore::run_impl(const PageFetcher&   fetcher,
         }
 
         if (!page_loaded) {
-            fail(page_result.error.empty() ? "Helio support-data request failed" : std::move(page_result.error));
+            fail(page_result.error.empty() ? "Helio support-data request failed" : std::move(page_result.error),
+                 run_generation);
             return false;
         }
 
@@ -433,28 +450,37 @@ bool SupportDataCatalogStore::run_impl(const PageFetcher&   fetcher,
     }
 
     if (staging.empty()) {
-        fail("Helio support-data response contained no supported entries");
+        fail("Helio support-data response contained no supported entries", run_generation);
         return false;
     }
 
-    publish(std::move(staging));
-    return true;
+    publish(std::move(staging), run_generation);
+    return is_run_current(run_generation);
 }
 
-void SupportDataCatalogStore::publish(std::vector<HelioSupportedData>&& complete_snapshot)
+void SupportDataCatalogStore::publish(std::vector<HelioSupportedData>&& complete_snapshot,
+                                      std::uint64_t                    run_generation)
 {
     auto snapshot = std::make_shared<const std::vector<HelioSupportedData>>(std::move(complete_snapshot));
 
     std::lock_guard<std::mutex> lock(m_mutex);
+    if (run_generation != m_generation) {
+        // The store was invalidated while this run was in flight; its data belongs to
+        // credentials that are no longer current, so drop it and keep the store reset.
+        return;
+    }
     m_snapshot    = std::move(snapshot);
     m_state       = SupportDataLoadState::Ready;
     m_last_error.clear();
     m_run_claimed = false;
 }
 
-void SupportDataCatalogStore::fail(std::string error)
+void SupportDataCatalogStore::fail(std::string error, std::uint64_t run_generation)
 {
     std::lock_guard<std::mutex> lock(m_mutex);
+    if (run_generation != m_generation) {
+        return;
+    }
     m_state       = SupportDataLoadState::Failed;
     m_last_error  = std::move(error);
     m_run_claimed = false;

--- a/src/slic3r/Utils/HelioSupportData.cpp
+++ b/src/slic3r/Utils/HelioSupportData.cpp
@@ -182,7 +182,7 @@ SupportDataPageResult parse_support_data_page(SupportDataCatalogKind        kind
                 }
             } else {
                 if (!required_string(object, "feedstock", item.feedstock)) {
-                    return incomplete_page(response, "Helio materials page contains an incomplete feedstock value");
+                    continue;
                 }
             }
 

--- a/src/slic3r/Utils/HelioSupportData.cpp
+++ b/src/slic3r/Utils/HelioSupportData.cpp
@@ -294,6 +294,14 @@ bool SupportDataCatalogStore::begin_pending_refresh()
     if (!m_pending_refresh) {
         return false;
     }
+    if (m_state == SupportDataLoadState::Loading) {
+        // Another run currently owns the store — e.g. invalidate() revoked this caller
+        // and a replacement load was started under the new generation. Only the run that
+        // actually completed (leaving the store Ready/Failed) may start the queued
+        // refresh; clearing m_run_claimed here would let a second worker claim the store
+        // concurrently and race to publish.
+        return false;
+    }
     m_pending_refresh = false;
     m_state           = SupportDataLoadState::Loading;
     m_last_error.clear();

--- a/src/slic3r/Utils/HelioSupportData.cpp
+++ b/src/slic3r/Utils/HelioSupportData.cpp
@@ -282,6 +282,12 @@ bool SupportDataCatalogStore::consume_pending_refresh()
     return true;
 }
 
+bool SupportDataCatalogStore::has_pending_refresh() const
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return m_pending_refresh;
+}
+
 bool SupportDataCatalogStore::claim_run()
 {
     std::lock_guard<std::mutex> lock(m_mutex);

--- a/src/slic3r/Utils/HelioSupportData.cpp
+++ b/src/slic3r/Utils/HelioSupportData.cpp
@@ -174,7 +174,12 @@ SupportDataPageResult parse_support_data_page(SupportDataCatalogKind        kind
             }
 
             if (kind == SupportDataCatalogKind::Printers) {
-                if (object.contains("heatedChamber")) {
+                // An explicit null means "capability unspecified", not "malformed": treat
+                // it as unknown and keep the default (false), matching how the previous
+                // loader and the alternativeNames handling below deal with nulls. Failing
+                // the page here would reject it identically on every retry and could leave
+                // the whole printer catalog Failed over one unspecified printer.
+                if (object.contains("heatedChamber") && !object["heatedChamber"].is_null()) {
                     if (!object["heatedChamber"].is_boolean()) {
                         return incomplete_page(response, "Helio printers page contains an invalid heatedChamber value");
                     }

--- a/src/slic3r/Utils/HelioSupportData.hpp
+++ b/src/slic3r/Utils/HelioSupportData.hpp
@@ -113,6 +113,7 @@ public:
     // fresh load with up-to-date credentials once the in-flight run completes, so a PAT
     // change that arrives mid-load is not silently dropped.
     bool consume_pending_refresh();
+    bool has_pending_refresh() const;
 
     bool run(const PageFetcher&  fetcher,
              const RetrySleeper& sleeper = RetrySleeper(),

--- a/src/slic3r/Utils/HelioSupportData.hpp
+++ b/src/slic3r/Utils/HelioSupportData.hpp
@@ -101,6 +101,9 @@ public:
     using Logger       = std::function<void(const SupportDataLoadAttempt&)>;
 
     static constexpr int MAX_ATTEMPTS_PER_PAGE = 4;
+    // How many times pagination may restart from page 1 when the backend reports a
+    // different total page count mid-walk (i.e. the catalog changed under us).
+    static constexpr int MAX_PAGINATION_RESTARTS = 2;
 
     explicit SupportDataCatalogStore(SupportDataCatalogKind kind);
 

--- a/src/slic3r/Utils/HelioSupportData.hpp
+++ b/src/slic3r/Utils/HelioSupportData.hpp
@@ -2,6 +2,7 @@
 
 #include "HelioRetryPolicy.hpp"
 
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -122,6 +123,10 @@ public:
 
     // Clears the snapshot and resets the store to NotLoaded. Use when credentials change
     // but no network refresh should start (e.g. Helio disabled or PAT removed).
+    // Any in-flight load is revoked as well: its run is generation-tagged, so it stops
+    // fetching further pages and can never publish (or fail) into the store afterwards.
+    // The next non-forced request therefore reloads with the current credentials instead
+    // of reusing the previous account's data.
     void invalidate();
 
     bool run(const PageFetcher&  fetcher,
@@ -136,10 +141,14 @@ public:
     SupportDataCatalogView view() const;
 
 private:
-    bool claim_run();
-    bool run_impl(const PageFetcher& fetcher, const RetrySleeper& sleeper, const Logger& logger);
-    void publish(std::vector<HelioSupportedData>&& complete_snapshot);
-    void fail(std::string error);
+    // Claims the pending run and reports the generation it belongs to. Results of a run
+    // whose generation is no longer current (invalidate() bumped it) are discarded.
+    bool claim_run(std::uint64_t& run_generation);
+    bool run_impl(const PageFetcher& fetcher, const RetrySleeper& sleeper, const Logger& logger,
+                  std::uint64_t run_generation);
+    void publish(std::vector<HelioSupportedData>&& complete_snapshot, std::uint64_t run_generation);
+    void fail(std::string error, std::uint64_t run_generation);
+    bool is_run_current(std::uint64_t run_generation) const;
 
     const SupportDataCatalogKind m_kind;
     mutable std::mutex           m_mutex;
@@ -148,6 +157,7 @@ private:
     std::string                  m_last_error;
     bool                         m_run_claimed{false};
     bool                         m_pending_refresh{false};
+    std::uint64_t                m_generation{0};
 };
 
 } // namespace Slic3r

--- a/src/slic3r/Utils/HelioSupportData.hpp
+++ b/src/slic3r/Utils/HelioSupportData.hpp
@@ -1,5 +1,4 @@
-#ifndef slic3r_HelioSupportData_hpp_
-#define slic3r_HelioSupportData_hpp_
+#pragma once
 
 #include "HelioRetryPolicy.hpp"
 
@@ -135,5 +134,3 @@ private:
 };
 
 } // namespace Slic3r
-
-#endif // slic3r_HelioSupportData_hpp_

--- a/src/slic3r/Utils/HelioSupportData.hpp
+++ b/src/slic3r/Utils/HelioSupportData.hpp
@@ -1,0 +1,139 @@
+#ifndef slic3r_HelioSupportData_hpp_
+#define slic3r_HelioSupportData_hpp_
+
+#include "HelioRetryPolicy.hpp"
+
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+namespace Slic3r {
+
+struct HelioSupportedData
+{
+    std::string id;
+    std::string name;
+    std::string native_name;
+    std::string feedstock;
+    bool        heated_chamber{false};
+};
+
+enum class SupportDataLoadState
+{
+    NotLoaded,
+    Loading,
+    Ready,
+    Failed
+};
+
+enum class SupportDataCatalogKind
+{
+    Printers,
+    Materials
+};
+
+struct SupportDataHttpResponse
+{
+    unsigned    status{0};
+    std::string body;
+    std::string error;
+    std::string trace_id;
+};
+
+struct SupportDataPageResult
+{
+    bool                            success{false};
+    bool                            has_next_page{false};
+    int                             total_pages{0};
+    unsigned                        status{0};
+    HelioRetryKind                  retry_kind{HelioRetryKind::None};
+    std::vector<HelioSupportedData> items;
+    std::string                     error;
+    std::string                     trace_id;
+};
+
+SupportDataPageResult parse_support_data_page(SupportDataCatalogKind       kind,
+                                              int                          page,
+                                              const SupportDataHttpResponse& response);
+
+struct SupportDataCatalogView
+{
+    using Snapshot = std::shared_ptr<const std::vector<HelioSupportedData>>;
+
+    SupportDataLoadState state{SupportDataLoadState::NotLoaded};
+    Snapshot             snapshot;
+    std::string          last_error;
+
+    bool has_usable_snapshot() const noexcept { return snapshot && !snapshot->empty(); }
+};
+
+enum class SupportDataAvailability
+{
+    Usable,
+    Synchronizing,
+    LoadFailed
+};
+
+SupportDataAvailability support_data_availability(const SupportDataCatalogView& printers,
+                                                  const SupportDataCatalogView& materials) noexcept;
+
+struct SupportDataLoadAttempt
+{
+    SupportDataCatalogKind kind{SupportDataCatalogKind::Printers};
+    int                    page{1};
+    int                    attempt{1};
+    int                    max_attempts{4};
+    unsigned               status{0};
+    HelioRetryKind         retry_kind{HelioRetryKind::None};
+    bool                   will_retry{false};
+    std::string            error;
+    std::string            trace_id;
+};
+
+class SupportDataCatalogStore
+{
+public:
+    using Snapshot     = SupportDataCatalogView::Snapshot;
+    using PageFetcher  = std::function<SupportDataHttpResponse(SupportDataCatalogKind, int)>;
+    using RetrySleeper = std::function<void(int)>;
+    using Logger       = std::function<void(const SupportDataLoadAttempt&)>;
+
+    static constexpr int MAX_ATTEMPTS_PER_PAGE = 4;
+
+    explicit SupportDataCatalogStore(SupportDataCatalogKind kind);
+
+    SupportDataCatalogStore(const SupportDataCatalogStore&) = delete;
+    SupportDataCatalogStore& operator=(const SupportDataCatalogStore&) = delete;
+
+    bool try_begin(bool force_refresh = false);
+
+    bool run(const PageFetcher&  fetcher,
+             const RetrySleeper& sleeper = RetrySleeper(),
+             const Logger&       logger = Logger());
+
+    SupportDataCatalogKind kind() const noexcept { return m_kind; }
+    SupportDataLoadState   state() const;
+    Snapshot               snapshot() const;
+    std::string            last_error() const;
+    bool                   has_usable_snapshot() const;
+    SupportDataCatalogView view() const;
+
+private:
+    bool claim_run();
+    bool run_impl(const PageFetcher& fetcher, const RetrySleeper& sleeper, const Logger& logger);
+    void publish(std::vector<HelioSupportedData>&& complete_snapshot);
+    void fail(std::string error);
+
+    const SupportDataCatalogKind m_kind;
+    mutable std::mutex           m_mutex;
+    SupportDataLoadState         m_state{SupportDataLoadState::NotLoaded};
+    Snapshot                     m_snapshot;
+    std::string                  m_last_error;
+    bool                         m_run_claimed{false};
+};
+
+} // namespace Slic3r
+
+#endif // slic3r_HelioSupportData_hpp_

--- a/src/slic3r/Utils/HelioSupportData.hpp
+++ b/src/slic3r/Utils/HelioSupportData.hpp
@@ -115,6 +115,15 @@ public:
     bool consume_pending_refresh();
     bool has_pending_refresh() const;
 
+    // Atomically consumes a pending refresh AND transitions the store to Loading state.
+    // This avoids the race where consume_pending_refresh() clears the flag but the store
+    // is briefly in Ready/Failed state before the follow-up try_begin() runs.
+    bool begin_pending_refresh();
+
+    // Clears the snapshot and resets the store to NotLoaded. Use when credentials change
+    // but no network refresh should start (e.g. Helio disabled or PAT removed).
+    void invalidate();
+
     bool run(const PageFetcher&  fetcher,
              const RetrySleeper& sleeper = RetrySleeper(),
              const Logger&       logger = Logger());

--- a/src/slic3r/Utils/HelioSupportData.hpp
+++ b/src/slic3r/Utils/HelioSupportData.hpp
@@ -108,6 +108,12 @@ public:
 
     bool try_begin(bool force_refresh = false);
 
+    // Returns true (and clears the flag) if a force-refresh was requested while a load
+    // was already in flight (see try_begin()). Callers should use this to re-trigger a
+    // fresh load with up-to-date credentials once the in-flight run completes, so a PAT
+    // change that arrives mid-load is not silently dropped.
+    bool consume_pending_refresh();
+
     bool run(const PageFetcher&  fetcher,
              const RetrySleeper& sleeper = RetrySleeper(),
              const Logger&       logger = Logger());
@@ -131,6 +137,7 @@ private:
     Snapshot                     m_snapshot;
     std::string                  m_last_error;
     bool                         m_run_claimed{false};
+    bool                         m_pending_refresh{false};
 };
 
 } // namespace Slic3r


### PR DESCRIPTION
# Description

Fixes #93 — The "Unsupported Materials Detected" error fires incorrectly on a second OrcaSlicer instance because the per-process support-data cache was empty while the async fetch was in-flight (or had failed).

**Root cause:** The old code used plain static `std::vector` + `bool` flags with no thread safety. On startup, `request_all_support_materials()` cleared the cache and set `fully_loaded = false`, then fired async HTTP requests. If the fetch failed or was still loading, the empty cache was treated as "everything is unsupported" — not "data hasn't loaded yet."

**Fix (ported from BambuStudio PR #63):**
- **New `HelioRetryPolicy.hpp/cpp`**: Retry classification for Helio HTTP and GraphQL responses (transient vs terminal vs backend-auth)
- **New `HelioSupportData.hpp/cpp`**: Thread-safe `SupportDataCatalogStore` with immutable snapshots, paginated loading with per-page retries, and a `SupportDataAvailability` state machine (`Usable` / `Synchronizing` / `LoadFailed`)
- **Modified `HelioDragon.hpp/cpp`**: Replaced the static vectors/bools with `SupportDataCatalogStore` singletons. Support data is now accessed via `snapshot()` which returns a `shared_ptr` for thread-safe reads. Background loading uses a worker thread pool with cancellation support
- **Modified `Plater.cpp`**: Gates the "Unsupported Materials" dialog on `SupportDataAvailability`. Shows "Synchronizing" when data is loading, and "Load Failed" with retry option when loading failed — never falsely flags materials as unsupported
- **Modified `GUI_App.cpp`**: Added `force_refresh` parameter to `request_helio_supported_data()`
- **Modified `HelioReleaseNote.cpp`**: Updated to use snapshot access

# Screenshots/Recordings/Graphs

N/A — behavioral fix, no UI layout changes.

## Tests

- The new `SupportDataCatalogStore` provides thread-safe snapshot access, ensuring concurrent reads never see partially-loaded data
- The `SupportDataAvailability` state machine correctly distinguishes NotLoaded/Loading/Ready/Failed states
- All existing `HelioQuery::global_supported_*` references have been migrated to snapshot-based access with null checks
- The fix was ported from the equivalent BambuStudio PR #63, which includes unit tests for retry classification and support-data pagination"

---
_Generated by [Claude Code](https://claude.ai/code/session_01QmCLmajhWGXTQAnFr2WR2n)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Helio printer/material catalogs now load via a background worker flow with explicit force-refresh triggers.
  * Added snapshot-based access to supported data plus “usable / synchronizing / failed” availability states to drive the UI.
  * Introduced retry classification and retry control for transient vs auth-related failures.
* **Bug Fixes**
  * Heated-chamber matching and name-to-ID resolution now use the latest available snapshot (and safely handle loading/not-usable states).
  * Refresh completion is gated on actual usability; failures show a clear “data load failed” dialog.
  * Background Helio loading is shut down on exit, and refresh callbacks are guarded to avoid acting after dialogs are destroyed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->