### PR TITLE
Document the Helio support-data catalog touchpoints in HELIO_INTEGRATION.md

### DIFF
--- a/HELIO_INTEGRATION.md
+++ b/HELIO_INTEGRATION.md
@@ -13,8 +13,11 @@
 > `render_position_window()` — the Helio TI rows/cases live there now.
 
 ## Stats
-- **64 files changed**: 32 new, 32 modified, 0 deleted
-- **+13,363 lines added, -195 lines removed**
+- **70 files changed**: 36 new, 34 modified, 0 deleted
+- **+13,363 lines added, -195 lines removed** — measured at the v2.4.0-beta sync.
+  The support-data catalog work (#95) adds ~1,000 further lines in the four new
+  `HelioSupportData` / `HelioRetryPolicy` files, plus the region-change hook in
+  `WebGuideDialog.cpp`.
 
 ## Architecture
 
@@ -38,13 +41,31 @@ Key data flow:
 - `HelioCompletionEvent` — carries result path + quality metrics to UI thread
 - Thermal Index — parsed from `;helioadditive=` gcode comments in `GCodeProcessor`
 
-## Helio-Only Files (32 files — NEVER exist upstream, always preserve)
+## Helio-Only Files (36 files — NEVER exist upstream, always preserve)
 
 ### Core API Client
 | File | Purpose |
 |-|-|
 | `src/slic3r/Utils/HelioDragon.hpp` | API client declarations: `HelioQuery`, `HelioBackgroundProcess`, `HelioPlateResult`, GraphQL types |
 | `src/slic3r/Utils/HelioDragon.cpp` | Full API implementation: auth, job dispatch, polling, gcode download, supported data cache |
+
+### Support Data Catalog
+Added by #95 (port of BambuStudio #63) — replaces the old thread-unsafe static
+vector/bool cache that produced false "Unsupported Materials" errors.
+| File | Purpose |
+|-|-|
+| `src/slic3r/Utils/HelioSupportData.hpp` | `SupportDataCatalogStore` declaration: snapshot-based catalog, `SupportDataLoadState` / `SupportDataAvailability` state machine, generation tagging, pending-refresh handoff |
+| `src/slic3r/Utils/HelioSupportData.cpp` | Store implementation: paginated loading with per-page retries, bounded pagination restarts, `invalidate()` revoking in-flight runs, publish/fail guarded by run generation |
+| `src/slic3r/Utils/HelioRetryPolicy.hpp` | Retry classification declarations for Helio HTTP/GraphQL responses |
+| `src/slic3r/Utils/HelioRetryPolicy.cpp` | `helio_classify_retry` / `helio_classify_graphql_response`: transient vs terminal failure classification |
+
+Readers must go through `HelioQuery::supported_printers_snapshot()` /
+`supported_materials_snapshot()` and gate on
+`HelioQuery::supported_data_availability()` — never on a bare "fetched" bool.
+Credential and endpoint changes must call
+`HelioQuery::invalidate_support_data_for_endpoint_change()` (region) or go
+through `set_helio_pat()` (PAT), both of which bump the credential generation so
+work started under the old credential can never land.
 
 ### UI Dialogs
 | File | Purpose |
@@ -92,7 +113,7 @@ Key data flow:
 | `.github/workflows/helio-upstream-sync.yml` | Upstream sync: merges upstream changes, creates conflict issues (labeled `claude-work`), creates sync PRs |
 | `.github/workflows/helio-upstream-watch.yml` | Monitors upstream for new tags/releases, creates tracking issues |
 
-## Modified Files (32 files — conflict risk, detailed per-file guide)
+## Modified Files (34 files — conflict risk, detailed per-file guide)
 
 ### CRITICAL RISK
 
@@ -183,14 +204,17 @@ The heaviest modification. Contains the entire Helio processing pipeline.
 - Added `#include "../Utils/HelioDragon.hpp"`
 - **New "Helio" tab** appended to preferences: enable toggle, PAT input (password field), multi-material toggle, API URL display
 - **Toggle listener**: `enable_helio_processing` toggle immediately shows/hides the Helio button in MainFrame via `ShowExpandButton()` + `Layout()` (no restart required)
+- **Region combobox**: both region-write paths call `HelioQuery::invalidate_support_data_for_endpoint_change()` — region selects both the Helio endpoint and which regional PAT key is read, so the previous endpoint's catalogs must be dropped
 
 #### `src/slic3r/GUI/GUI_App.cpp` (+28)
 - Added `#include "../Utils/HelioDragon.hpp"`
 - Startup initialization block: always requests Helio supported data on startup (no "already loaded" guard)
-- New methods: `is_helio_enable()`, `request_helio_pat()`, `request_helio_supported_data()`
+- New methods: `is_helio_enable()`, `request_helio_pat()`, `request_helio_supported_data(bool force_refresh = false)`
+- `OnExit()` calls `HelioQuery::shutdown_background_requests()` so support-data
+  workers are torn down cleanly — keep this line when upstream reworks `OnExit()`
 
 #### `src/slic3r/GUI/GUI_App.hpp` (+4)
-- 4 method declarations: `is_helio_enable()`, `request_helio_pat()`, `request_helio_supported_data()`
+- 4 method declarations: `is_helio_enable()`, `request_helio_pat()`, `request_helio_supported_data(bool force_refresh = false)`
 
 #### `src/slic3r/GUI/PartPlate.cpp` (+27)
 - Added `#include "../Utils/HelioDragon.hpp"`
@@ -247,8 +271,16 @@ The heaviest modification. Contains the entire Helio processing pipeline.
 #### `src/libvgcode/include/Types.hpp` (+2)
 - Appended 3 enum values to `EViewType`: `ThermalIndexMean`, `ThermalIndexMin`, `ThermalIndexMax`
 
-#### `src/slic3r/CMakeLists.txt` (+8)
-- Appended 8 source file entries (4 hpp + 4 cpp for Helio files)
+#### `src/slic3r/CMakeLists.txt` (+12)
+- Appended 12 source file entries (6 hpp + 6 cpp for Helio files), including
+  `Utils/HelioSupportData.{cpp,hpp}` and `Utils/HelioRetryPolicy.{cpp,hpp}`
+
+#### `src/slic3r/GUI/WebGuideDialog.cpp` (+7)
+- Added `#include "slic3r/Utils/HelioDragon.hpp"`
+- `GuideFrame::SaveProfile()` writes `region` directly (a second setter alongside
+  Preferences), so it calls `HelioQuery::invalidate_support_data_for_endpoint_change()`
+  when the region actually changed — otherwise catalogs from the previous endpoint
+  survive a wizard-driven region switch
 
 #### `src/slic3r/GUI/GLCanvas3D.cpp` (+4/-1)
 - Null-guard fix: added `get_notification_manager()` null check in existing condition
@@ -327,7 +359,7 @@ Helio includes go after the last upstream include in the same category:
 
 ### Rule 9: Never Remove
 Any line containing these identifiers must be preserved:
-`helio`, `Helio`, `HELIO`, `thermal_index`, `ThermalIndex`, `HelioPlateResult`, `HelioQuery`, `HelioBackgroundProcess`, `HelioCompletionEvent`, `helioadditive`, `EVT_HELIO`, `EVT_GLTOOLBAR_ACTION_HELIO`
+`helio`, `Helio`, `HELIO`, `thermal_index`, `ThermalIndex`, `HelioPlateResult`, `HelioQuery`, `HelioBackgroundProcess`, `HelioCompletionEvent`, `helioadditive`, `EVT_HELIO`, `EVT_GLTOOLBAR_ACTION_HELIO`, `SupportDataCatalogStore`, `SupportDataAvailability`, `SupportDataLoadState`
 
 ### Rule 10: API Renames
 If upstream renames functions that Helio calls, update Helio code to use the new name:

--- a/HELIO_INTEGRATION.md
+++ b/HELIO_INTEGRATION.md
@@ -44,6 +44,7 @@ Key data flow:
 ## Helio-Only Files (36 files — NEVER exist upstream, always preserve)
 
 ### Core API Client
+
 | File | Purpose |
 |-|-|
 | `src/slic3r/Utils/HelioDragon.hpp` | API client declarations: `HelioQuery`, `HelioBackgroundProcess`, `HelioPlateResult`, GraphQL types |
@@ -52,6 +53,7 @@ Key data flow:
 ### Support Data Catalog
 Added by #95 (port of BambuStudio #63) — replaces the old thread-unsafe static
 vector/bool cache that produced false "Unsupported Materials" errors.
+
 | File | Purpose |
 |-|-|
 | `src/slic3r/Utils/HelioSupportData.hpp` | `SupportDataCatalogStore` declaration: snapshot-based catalog, `SupportDataLoadState` / `SupportDataAvailability` state machine, generation tagging, pending-refresh handoff |
@@ -60,14 +62,15 @@ vector/bool cache that produced false "Unsupported Materials" errors.
 | `src/slic3r/Utils/HelioRetryPolicy.cpp` | `helio_classify_retry` / `helio_classify_graphql_response`: transient vs terminal failure classification |
 
 Readers must go through `HelioQuery::supported_printers_snapshot()` /
-`supported_materials_snapshot()` and gate on
+`HelioQuery::supported_materials_snapshot()` and gate on
 `HelioQuery::supported_data_availability()` — never on a bare "fetched" bool.
 Credential and endpoint changes must call
 `HelioQuery::invalidate_support_data_for_endpoint_change()` (region) or go
-through `set_helio_pat()` (PAT), both of which bump the credential generation so
-work started under the old credential can never land.
+through `HelioQuery::set_helio_pat()` (PAT), both of which bump the credential
+generation so work started under the old credential can never land.
 
 ### UI Dialogs
+
 | File | Purpose |
 |-|-|
 | `src/slic3r/GUI/HelioReleaseNote.hpp` | All Helio dialog declarations: `HelioInputDialog`, `HelioResultDialog`, `HelioStatusNotification` |
@@ -76,12 +79,14 @@ work started under the old credential can never land.
 | `src/slic3r/GUI/HelioHistoryDialog.cpp` | History dialog: lists past Helio jobs, re-download results |
 
 ### Widgets
+
 | File | Purpose |
 |-|-|
 | `src/slic3r/GUI/Widgets/LinkLabel.hpp` | Clickable hyperlink label widget declaration |
 | `src/slic3r/GUI/Widgets/LinkLabel.cpp` | LinkLabel implementation |
 
 ### Resources
+
 | File | Purpose |
 |-|-|
 | `resources/images/expand_helio.png` | Helio button icon (toolbar) |
@@ -107,6 +112,7 @@ work started under the old credential can never land.
 | `resources/data/helio_hints.ini` | First-time tutorial hint text |
 
 ### CI/CD Workflows (Helio-only)
+
 | File | Purpose |
 |-|-|
 | `.github/workflows/helio-release.yml` | Release workflow: builds all platforms, creates GitHub Release with Helio-prefixed assets. Triggers on merged PR with `release` label or manual `workflow_dispatch` (restricted to `orca-latest-parity-bambu`) |
@@ -208,7 +214,7 @@ The heaviest modification. Contains the entire Helio processing pipeline.
 
 #### `src/slic3r/GUI/GUI_App.cpp` (+28)
 - Added `#include "../Utils/HelioDragon.hpp"`
-- Startup initialization block: always requests Helio supported data on startup (no "already loaded" guard)
+- The startup block always requests the Helio supported-data catalogs (no "already loaded" guard)
 - New methods: `is_helio_enable()`, `request_helio_pat()`, `request_helio_supported_data(bool force_refresh = false)`
 - `OnExit()` calls `HelioQuery::shutdown_background_requests()` so support-data
   workers are torn down cleanly — keep this line when upstream reworks `OnExit()`


### PR DESCRIPTION
# Description

`HELIO_INTEGRATION.md` is the reference an upstream-sync resolver reads before touching anything, but it still describes the pre-#95 world. PR #95 added four Helio-only files and a new region-change touchpoint that the map never picked up — a resolver reading it today would not know those files exist, that they must never be dropped, or that `WebGuideDialog.cpp` now carries Helio code.

This came up while rebasing the v2.4.2 sync (#96) onto the current release branch tip: verifying that nothing from #95 was lost meant reconstructing the touchpoint list by hand because the map did not have it.

Changes, all documentation:

- **New "Support Data Catalog" section** under Helio-Only Files for `HelioSupportData.{cpp,hpp}` and `HelioRetryPolicy.{cpp,hpp}`, plus the contract callers depend on: read through `supported_*_snapshot()` and gate on `supported_data_availability()`, never on a bare "fetched" bool; credential/endpoint changes go through `invalidate_support_data_for_endpoint_change()` or `set_helio_pat()` so the generation is bumped.
- **`src/slic3r/GUI/WebGuideDialog.cpp`** added as a modified-file touchpoint — the setup wizard is a second `region` writer and must invalidate catalogs on a real region change.
- **`GUI_App.cpp` / `.hpp`**: note the `OnExit()` → `shutdown_background_requests()` call and the `force_refresh` parameter on `request_helio_supported_data()`.
- **`Preferences.cpp`**: note the region-combobox invalidation on both write paths.
- **`CMakeLists.txt`**: corrected from 8 to 12 appended source entries.
- **Rule 9 (never remove)**: added `SupportDataCatalogStore`, `SupportDataAvailability`, `SupportDataLoadState` so the standard grep self-check covers the new types.
- **Stats**: file counts refreshed against the actual tables (36 Helio-only, 34 modified); the line totals are now explicitly scoped to the sync they were measured at rather than silently implying they still hold.

# Screenshots/Recordings/Graphs

N/A — documentation only.

## Tests

No code changes, so no build or test impact. Verified by counting the entries in both tables programmatically (36 Helio-only rows, 34 modified-file entries) rather than trusting the previous header numbers, and by checking each newly documented symbol against the merged tree.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KMcJUkgD6iXMMFhg1XypQ4)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated Helio integration documentation for the v2.4.0-beta upstream sync.
  - Documented support-data catalog loading, retry handling, refresh behavior, region changes, and shutdown handling.
  - Expanded workflow and support-data coverage, including catalog components, build details, and preserved identifiers.
  - Updated the integration map with current file and component listings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->