### PR TITLE
Skip issue dedupe cleanly when CLAUDE_CODE_OAUTH_TOKEN is unset

### DIFF
--- a/.github/workflows/dedupe-issues.yml
+++ b/.github/workflows/dedupe-issues.yml
@@ -19,10 +19,31 @@ jobs:
       issues: write
 
     steps:
+      - name: Check Claude credentials
+        id: creds
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: |
+          if [ -z "$CLAUDE_CODE_OAUTH_TOKEN" ]; then
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "::warning title=Issue dedupe skipped::CLAUDE_CODE_OAUTH_TOKEN is not configured for this repository, so duplicate detection did not run. Add the secret in Settings -> Secrets and variables -> Actions, then re-run this workflow via workflow_dispatch with the issue number."
+            {
+              echo "### Issue dedupe skipped"
+              echo
+              echo "\`CLAUDE_CODE_OAUTH_TOKEN\` is not configured, so \`/dedupe\` did not run for issue #${{ github.event.issue.number || inputs.issue_number }}."
+              echo
+              echo "Add the secret under **Settings -> Secrets and variables -> Actions**, then re-run this workflow with \`workflow_dispatch\` and the issue number."
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout repository
+        if: steps.creds.outputs.configured == 'true'
         uses: actions/checkout@v6
 
       - name: Run Claude Code slash command
+        if: steps.creds.outputs.configured == 'true'
         uses: anthropics/claude-code-base-action@beta
         with:
           prompt: "/dedupe ${{ github.repository }}/issues/${{ github.event.issue.number || inputs.issue_number }}"
@@ -32,7 +53,7 @@ jobs:
             GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Log duplicate comment event to Statsig
-        if: always()
+        if: always() && steps.creds.outputs.configured == 'true'
         env:
           STATSIG_API_KEY: ${{ secrets.STATSIG_API_KEY }}
         run: |

--- a/.github/workflows/dedupe-issues.yml
+++ b/.github/workflows/dedupe-issues.yml
@@ -23,6 +23,9 @@ jobs:
         id: creds
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Passed through the environment, never interpolated into the script body:
+          # `inputs.issue_number` is a free-form workflow_dispatch string.
+          ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue_number }}
         run: |
           if [ -z "$CLAUDE_CODE_OAUTH_TOKEN" ]; then
             echo "configured=false" >> "$GITHUB_OUTPUT"
@@ -30,7 +33,7 @@ jobs:
             {
               echo "### Issue dedupe skipped"
               echo
-              echo "\`CLAUDE_CODE_OAUTH_TOKEN\` is not configured, so \`/dedupe\` did not run for issue #${{ github.event.issue.number || inputs.issue_number }}."
+              echo "\`CLAUDE_CODE_OAUTH_TOKEN\` is not configured, so \`/dedupe\` did not run for issue #${ISSUE_NUMBER}."
               echo
               echo "Add the secret under **Settings -> Secrets and variables -> Actions**, then re-run this workflow with \`workflow_dispatch\` and the issue number."
             } >> "$GITHUB_STEP_SUMMARY"
@@ -41,6 +44,10 @@ jobs:
       - name: Checkout repository
         if: steps.creds.outputs.configured == 'true'
         uses: actions/checkout@v6
+        with:
+          # Nothing here pushes; don't leave the token in .git/config for the
+          # Claude step (and any tooling it shells out to) to pick up.
+          persist-credentials: false
 
       - name: Run Claude Code slash command
         if: steps.creds.outputs.configured == 'true'
@@ -56,20 +63,33 @@ jobs:
         if: always() && steps.creds.outputs.configured == 'true'
         env:
           STATSIG_API_KEY: ${{ secrets.STATSIG_API_KEY }}
+          # Same reasoning as the credentials step: keep untrusted-ish values out
+          # of the script text so they can never be command-substituted.
+          ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue_number }}
+          REPO: ${{ github.repository }}
+          TRIGGERED_BY: ${{ github.event_name }}
+          RUN_ID: ${{ github.run_id }}
         run: |
-          ISSUE_NUMBER=${{ github.event.issue.number || inputs.issue_number }}
-          REPO=${{ github.repository }}
-          
           if [ -z "$STATSIG_API_KEY" ]; then
             echo "STATSIG_API_KEY not found, skipping Statsig logging"
             exit 0
           fi
-          
+
+          # `tonumber` aborts jq on anything non-numeric, which would fail the
+          # step over a telemetry payload. Validate before we get there.
+          case "$ISSUE_NUMBER" in
+            ''|*[!0-9]*)
+              echo "ISSUE_NUMBER '${ISSUE_NUMBER}' is not a positive integer, skipping Statsig logging"
+              exit 0
+              ;;
+          esac
+
           # Prepare the event payload
           EVENT_PAYLOAD=$(jq -n \
             --arg issue_number "$ISSUE_NUMBER" \
             --arg repo "$REPO" \
-            --arg triggered_by "${{ github.event_name }}" \
+            --arg triggered_by "$TRIGGERED_BY" \
+            --arg workflow_run_id "$RUN_ID" \
             '{
               events: [{
                 eventName: "github_duplicate_comment_added",
@@ -78,7 +98,7 @@ jobs:
                   repository: $repo,
                   issue_number: ($issue_number | tonumber),
                   triggered_by: $triggered_by,
-                  workflow_run_id: "${{ github.run_id }}"
+                  workflow_run_id: $workflow_run_id
                 },
                 time: (now | floor | tostring)
               }]

--- a/.github/workflows/dedupe-issues.yml
+++ b/.github/workflows/dedupe-issues.yml
@@ -77,9 +77,20 @@ jobs:
 
           # `tonumber` aborts jq on anything non-numeric, which would fail the
           # step over a telemetry payload. Validate before we get there.
+          #
+          # Zero is rejected as well as empty/non-digit: there is no issue #0, so
+          # a dispatch with issue_number=0 fails the Claude step but would still
+          # reach here (the step is `always()`) and log an event for a
+          # nonexistent issue. First arm catches empty/non-digits, second accepts
+          # anything with a non-zero digit, third rejects all-zero forms.
           case "$ISSUE_NUMBER" in
             ''|*[!0-9]*)
               echo "ISSUE_NUMBER '${ISSUE_NUMBER}' is not a positive integer, skipping Statsig logging"
+              exit 0
+              ;;
+            *[!0]*) ;;
+            *)
+              echo "ISSUE_NUMBER '${ISSUE_NUMBER}' is zero, which is not a valid issue number, skipping Statsig logging"
               exit 0
               ;;
           esac

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,13 @@ This is the Helio-Additive fork of OrcaSlicer. For Helio integration details, co
 - Logs events to Statsig (optional, skips if `STATSIG_API_KEY` not set)
 - **Missing-credential handling**: a preflight `Check Claude credentials` step gates the checkout, the Claude run, and the Statsig log. When `CLAUDE_CODE_OAUTH_TOKEN` is empty the job skips those steps and finishes green, emitting a `::warning::` annotation and a job-summary note instead. Without this the `anthropics/claude-code-base-action` step aborts with `Environment variable validation failed`, so every newly-opened issue leaves a red X on the release branch's run history and masks real CI failures. The dedupe still does not run — the secret is the fix; the guard only stops the misconfiguration from looking like a build break. Re-run with `workflow_dispatch` + issue number once the secret is added.
 
+### Backfill Duplicate Comments (`backfill-duplicate-comments.yml` / `scripts/backfill-duplicate-comments.ts`)
+- Manual `workflow_dispatch` only. Walks existing issues and dispatches the dedupe workflow for any that lack a duplicate-detection comment
+- `DRY_RUN` defaults to `true`; it must be explicitly set to `"false"` to actually dispatch
+- **Owner/repo and ref come from the runner** (`GITHUB_REPOSITORY`, `GITHUB_REF_NAME`), not hardcoded. Inherited upstream values pinned this to `OrcaSlicer/OrcaSlicer` on `main`, so a run from this fork read *upstream's* issue list and tried to dispatch into *upstream's* repo. Fallbacks are `Helio-Additive/OrcaSlicer` and `orca-latest-parity-bambu`
+- The dispatch target is `dedupe-issues.yml`. Upstream's name for it, `claude-dedupe-issues.yml`, has never existed in this fork — every dispatch 404'd
+- **Known gap**: the workflow accepts a `days_back` input and passes it as `DAYS_BACK`, but the script filters by issue number (`MIN_ISSUE_NUMBER` / `MAX_ISSUE_NUMBER`) and never reads it. The input currently does nothing. The `MAX_ISSUE_NUMBER` default in the script's usage text (`4050`) also disagrees with the code (`11000`)
+
 ### Upstream Watch (`helio-upstream-watch.yml`)
 - Monitors upstream for new tags/releases and creates tracking issues
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,7 @@ This is the Helio-Additive fork of OrcaSlicer. For Helio integration details, co
 - Requires `CLAUDE_CODE_OAUTH_TOKEN` secret configured in repo settings
 - Model: `claude-sonnet-4-6`
 - Logs events to Statsig (optional, skips if `STATSIG_API_KEY` not set)
+- **Missing-credential handling**: a preflight `Check Claude credentials` step gates the checkout, the Claude run, and the Statsig log. When `CLAUDE_CODE_OAUTH_TOKEN` is empty the job skips those steps and finishes green, emitting a `::warning::` annotation and a job-summary note instead. Without this the `anthropics/claude-code-base-action` step aborts with `Environment variable validation failed`, so every newly-opened issue leaves a red X on the release branch's run history and masks real CI failures. The dedupe still does not run — the secret is the fix; the guard only stops the misconfiguration from looking like a build break. Re-run with `workflow_dispatch` + issue number once the secret is added.
 
 ### Upstream Watch (`helio-upstream-watch.yml`)
 - Monitors upstream for new tags/releases and creates tracking issues

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,7 @@ This is the Helio-Additive fork of OrcaSlicer. For Helio integration details, co
 - `DRY_RUN` defaults to `true`; it must be explicitly set to `"false"` to actually dispatch
 - **Owner/repo and ref come from the runner** (`GITHUB_REPOSITORY`, `GITHUB_REF_NAME`), not hardcoded. Inherited upstream values pinned this to `OrcaSlicer/OrcaSlicer` on `main`, so a run from this fork read *upstream's* issue list and tried to dispatch into *upstream's* repo. Fallbacks are `Helio-Additive/OrcaSlicer` and `orca-latest-parity-bambu`
 - The dispatch target is `dedupe-issues.yml`. Upstream's name for it, `claude-dedupe-issues.yml`, has never existed in this fork — every dispatch 404'd
+- **Pull requests are filtered out.** `GET /issues` returns PRs alongside issues; entries carrying a `pull_request` field are skipped. This only started to matter once the dispatch worked — while it 404'd, dispatching for a PR was harmless
 - **Known gap**: the workflow accepts a `days_back` input and passes it as `DAYS_BACK`, but the script filters by issue number (`MIN_ISSUE_NUMBER` / `MAX_ISSUE_NUMBER`) and never reads it. The input currently does nothing. The `MAX_ISSUE_NUMBER` default in the script's usage text (`4050`) also disagrees with the code (`11000`)
 
 ### Upstream Watch (`helio-upstream-watch.yml`)

--- a/scripts/backfill-duplicate-comments.ts
+++ b/scripts/backfill-duplicate-comments.ts
@@ -56,12 +56,15 @@ async function triggerDedupeWorkflow(
     return;
   }
 
+  // The dedupe workflow in this fork is `dedupe-issues.yml`; `claude-dedupe-issues.yml`
+  // never existed here and every dispatch 404'd. Default the ref to the release branch
+  // rather than `main` — that is where the fork's workflows are maintained.
   await githubRequest(
-    `/repos/${owner}/${repo}/actions/workflows/claude-dedupe-issues.yml/dispatches`,
+    `/repos/${owner}/${repo}/actions/workflows/dedupe-issues.yml/dispatches`,
     token,
     'POST',
     {
-      ref: 'main',
+      ref: process.env.GITHUB_REF_NAME || 'orca-latest-parity-bambu',
       inputs: {
         issue_number: issueNumber.toString()
       }
@@ -86,8 +89,16 @@ Environment Variables:
   }
   console.log("[DEBUG] GitHub token found");
 
-  const owner = "OrcaSlicer";
-  const repo = "OrcaSlicer";
+  // Derived from the runner, not hardcoded. These were pinned to upstream
+  // `OrcaSlicer/OrcaSlicer`, so a run from this fork read upstream's issues and
+  // tried to dispatch into upstream's repo with this repo's token.
+  const repository = process.env.GITHUB_REPOSITORY || "Helio-Additive/OrcaSlicer";
+  const [owner, repo] = repository.split("/");
+  if (!owner || !repo || repository.split("/").length !== 2) {
+    throw new Error(
+      `GITHUB_REPOSITORY is malformed: "${repository}" (expected "owner/repo")`
+    );
+  }
   const dryRun = process.env.DRY_RUN !== "false";
   const maxIssueNumber = parseInt(process.env.MAX_ISSUE_NUMBER || "11000", 10);
   const minIssueNumber = parseInt(process.env.MIN_ISSUE_NUMBER || "1", 10);

--- a/scripts/backfill-duplicate-comments.ts
+++ b/scripts/backfill-duplicate-comments.ts
@@ -14,6 +14,9 @@ interface GitHubIssue {
   user: { id: number };
   created_at: string;
   closed_at?: string;
+  // Present only on pull requests. `/issues` returns PRs alongside issues, and
+  // this is the documented way to tell them apart.
+  pull_request?: { url: string };
 }
 
 interface GitHubComment {
@@ -120,8 +123,15 @@ Environment Variables:
     
     if (pageIssues.length === 0) break;
     
-    // Filter to only include issues within the specified range
-    const filteredIssues = pageIssues.filter(issue => 
+    // Filter to only include issues within the specified range.
+    // `/issues` returns pull requests too, and dedupe is issue-only — dispatching
+    // for a PR burns a run and logs a Statsig event for work that cannot apply.
+    const pullRequestsSkipped = pageIssues.filter(issue => issue.pull_request).length;
+    if (pullRequestsSkipped > 0) {
+      console.log(`[DEBUG] Skipping ${pullRequestsSkipped} pull request(s) in page #${page}`);
+    }
+    const filteredIssues = pageIssues.filter(issue =>
+      !issue.pull_request &&
       issue.number >= minIssueNumber && issue.number < maxIssueNumber
     );
     allIssues.push(...filteredIssues);


### PR DESCRIPTION
# Description

Fixes the failing **Orca Issue Dedupe** run on `orca-latest-parity-bambu` — [run 31232196763](https://github.com/Helio-Additive/OrcaSlicer/actions/runs/31232196763), triggered by issue #104 being opened.

**Root cause is configuration, not code.** `CLAUDE_CODE_OAUTH_TOKEN` is not set for this repository, so `anthropics/claude-code-base-action@beta` aborts immediately:

```
##[error]Action failed with error: Error: Environment variable validation failed:
  - Either ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN is required when using direct Anthropic API.
##[error]Process completed with exit code 1.
```

The workflow triggers on `issues: opened`, so **every new issue leaves a red X on the release branch's run history** for a missing secret. That is the kind of persistent failure that trains people to ignore the run list and masks a real CI break when one shows up.

**What this changes:** a preflight `Check Claude credentials` step gates the checkout, the Claude run, and the Statsig log on the secret being present. When it is missing the job finishes green, emitting a `::warning::` annotation and a job-summary note that names the secret and the settings path.

**What this does not change:** dedupe still does not run without the secret — adding it is the actual fix, and this PR cannot do that (repo-admin action). The guard only stops a configuration gap from presenting as a build failure. Once the secret is added, re-run via `workflow_dispatch` with the issue number to dedupe #104 retroactively.

The Statsig step is gated too. It previously ran `if: always()`, so a run where dedupe never executed still logged a `github_duplicate_comment_added` event — an event for work that did not happen.

`CLAUDE.md` updated per the repo's documentation-maintenance rule (workflow file changed).

# Screenshots/Recordings/Graphs

N/A — CI workflow change, no UI surface.

## Tests

- `dedupe-issues.yml` parses as valid YAML; step gating verified: `Checkout` / `Run Claude Code slash command` on `steps.creds.outputs.configured == 'true'`, Statsig on `always() && steps.creds.outputs.configured == 'true'`
- No build or slicer code touched — the full build matrix is unaffected by this diff
- Cannot be exercised end-to-end from a PR: the failing path only triggers on `issues: opened`. Verification that the guard produces a green skip rather than a red failure needs either the next opened issue or a `workflow_dispatch` run.

---
_Generated by [Claude Code](https://claude.ai/code/session_013Z5k3V22bENf7zWguLrcGx)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Issue deduplication workflows now complete successfully when Claude credentials are unavailable.
  * Added clear warnings and workflow summaries explaining when credential-dependent steps are skipped.
  * Prevented unnecessary checkout, analysis, and logging steps from running without required credentials.
  * Improved credential checks and issue-number validation for more reliable workflow runs.

* **Documentation**
  * Documented the workflow behavior when Claude credentials are not configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes issue deduplication skip cleanly when Claude credentials are unavailable and repairs the duplicate-comment backfill target.
- Adds a credential preflight that gates checkout, Claude execution, and Statsig logging.
- Moves workflow values into environment variables and validates issue numbers before telemetry submission.
- Updates backfill dispatches to use the runner repository and ref while excluding pull requests.
- Documents the workflow and backfill behavior in `CLAUDE.md`.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/dedupe-issues.yml | Adds credential-aware execution gates, safer shell inputs, issue-number validation, and conditional telemetry. |
| scripts/backfill-duplicate-comments.ts | Corrects the repository, workflow, and ref used for backfill dispatches and filters pull requests from issue results. |
| CLAUDE.md | Documents missing-credential behavior, backfill operation, corrected dispatch configuration, and known limitations. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Issue opened or manual dispatch] --> B{Claude OAuth token configured?}
    B -- No --> C[Emit warning and job summary]
    B -- Yes --> D[Checkout without persisted credentials]
    D --> E[Run Claude dedupe command]
    E --> F[Validate issue number]
    F -- Invalid --> G[Skip Statsig logging]
    F -- Valid --> H[Send Statsig event]
    I[Manual backfill] --> J[Read issues from runner repository]
    J --> K{Pull request?}
    K -- Yes --> L[Skip entry]
    K -- No --> M[Dispatch dedupe workflow at runner ref]
```
</details>

<sub>Reviews (5): Last reviewed commit: ["Skip pull requests in the dedupe backfil..."](https://github.com/helio-additive/orcaslicer/commit/c75950b35d19d641c35f525bdd8c123b0f3e2155) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51514284)</sub>

<!-- /greptile_comment -->