### PR TITLE
Initialize Print::m_origin and m_isBBLPrinter (fixes the flaky Model construction test)

### DIFF
--- a/src/libslic3r/Print.hpp
+++ b/src/libslic3r/Print.hpp
@@ -1154,7 +1154,7 @@ private:
     PrintRegionPtrs                         m_print_regions;
     
     //SoftFever
-    bool m_isBBLPrinter;
+    bool m_isBBLPrinter = false;
 
     // Ordered collections of extrusion paths to build skirt loops and brim.
     ExtrusionEntityCollection               m_skirt;
@@ -1189,7 +1189,7 @@ private:
     std::vector<unsigned int> m_slice_used_filaments_first_layer;
 
     //BBS: plate's origin
-    Vec3d   m_origin;
+    Vec3d   m_origin {0, 0, 0};
     //BBS: modified_count
     int     m_modified_count {0};
     //BBS


### PR DESCRIPTION
# Description

Fixes #115, and thereby unblocks #113 — this is the intermittent `Coordinate outside allowed range` failure in `157 - Scenario: Model construction` that red-lighted #113's `Unit Tests` twice on byte-identical build inputs.

Two data members of `Print` were declared without initializers:

```cpp
bool m_isBBLPrinter;      // Print.hpp:1157
Vec3d   m_origin;         // Print.hpp:1192
```

Both are assigned only from GUI code (`BackgroundSlicingProcess.cpp`, `PartPlate`, `CalibUtils.cpp`), so a bare `Slic3r::Print` in a headless test reads whatever the stack happens to hold. For `m_origin` that is fatal in exactly the observed way: `get_plate_origin()` feeds

```cpp
p.translate(scale_(print_origin.x()), scale_(print_origin.y()));   // Print.cpp:618, 940
```

and the G-code export offset (`Print.cpp:2636`, `3566`), so garbage doubles get scaled by 1e6 and cast to `int64` — undefined behavior whose typical result lands far outside ClipperLib's ±4.6×10¹⁸ range and throws on `AddPath`. Intermittent because it depends on what the uninitialized memory happens to hold on that run.

## This is upstream's own diagnosis, missing from v2.4.2

Not a novel theory — upstream hit the same exception in the same suite, root-caused it, and fixed it with these exact initializers:

- [SoftFever/OrcaSlicer@`99dea01c`](https://github.com/SoftFever/OrcaSlicer/commit/99dea01cc38157454894ad409b344ced93fd79bc) — *"Fix coord out-of-range exception caused by `m_origin` memory not initialized to 0"* (2026-06-22)
- [SoftFever/OrcaSlicer@`f7d14b12`](https://github.com/SoftFever/OrcaSlicer/commit/f7d14b12b261983e897121b69b3a566e347b0afe) — *"fix: initialize Print::m_isBBLPrinter"* (2026-06-26, PR [#14426](https://github.com/SoftFever/OrcaSlicer/pull/14426)) — same class of bug, different symptom: non-deterministically dropped per-feature filament assignments via `ToolOrdering` in headless runs

Both landed on upstream `main` **after the 2.4.x release branch was cut** and were never backported: the `v2.4.2` tag's `Print.hpp` blob is byte-identical to this fork's, still carrying both uninitialized members (content-verified, not inferred from dates). The same defect family is why upstream quarantined three fff_print tests as `[NotWorking]` in June ([#14207](https://github.com/SoftFever/OrcaSlicer/pull/14207) — the quarantine comments are still verbatim in this tree at `tests/fff_print/test_printgcode.cpp:33` and `test_skirt_brim.cpp:35`); upstream un-quarantined them after these fixes. Test 157 drives the same slice/export pipeline unquarantined, which is why this fork sees the flake there.

## Why the alternative suspects are ruled out

The arrange step (`test_model.cpp:45`) was audited in depth: for this input — one instance, `InfiniteBed` — it is single-threaded, deterministic, and lands the cube at (90mm, 90mm); even its worst *legal* internal coordinate (the pre-align infinite-bed corner, ≈2.3×10¹⁸) is under clipper's throw threshold, so arrange cannot produce this message at all. The other in-tree throw site with this message (`TreeSupport3D.cpp:71`) is unreachable — supports are off in `full_print_config()`. Producing the observed exception requires genuine garbage, and `m_origin` is the reachable source of it on this path.

# Screenshots/Recordings/Graphs

N/A — two initializers, no UI surface.

## Tests

- **Evidence base**: 39 known Unit Tests executions over 3 months in this repo; test 157 is the only test that has ever failed non-deterministically (2 failing executions, both on one merge ref; 37 clean executions elsewhere — including the same binary inputs passing on the base branch 9 minutes before the first failure).
- `ready-to-build` will be applied to run the full matrix + Unit Tests on this PR.
- **Honest limit**: a flake cannot be *proven* fixed by green runs — upstream itself noted the failure "does not reproduce locally". The argument for this fix is the verified mechanism (uninitialized read → UB cast → out-of-range clipper input, with every link checked in this tree) plus upstream having independently reached and shipped the identical fix. If 157 ever throws this exception again after this merges, #115 should be reopened and the next suspect is the un-backported guards in the NFP placer (documented in #115).

**Merge order note:** merge this first, then #113 gets its base refreshed and re-checked — its red `Unit Tests` becomes green without touching #113's own diff.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0181jdoWcjHRDKQDiHj512i4

---
_Generated by [Claude Code](https://claude.ai/code/session_0181jdoWcjHRDKQDiHj512i4)_

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Initializes two previously indeterminate `Print` members to deterministic, benign defaults, preventing headless construction from consuming garbage state.
- Defaults `m_isBBLPrinter` to `false`.
- Defaults `m_origin` to the zero vector.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no actionable regressions identified.

The new initializers replace indeterminate values with valid defaults, while configured GUI paths continue to overwrite the fields explicitly.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/libslic3r/Print.hpp | Adds valid in-class defaults for printer identity and plate origin without changing explicitly configured GUI paths. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Initialize Print::m\_origin and m\_isBBLPr..."](https://github.com/helio-additive/orcaslicer/commit/4dab5d35eb63d4cdce664d259b6ac2be3e60e4b0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54237269)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved print initialization reliability by ensuring printer status and origin values start with consistent defaults.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->