### PR TITLE
Take upstream-watch off the helio-last-synced tag (step 1 of dropping it)

### DIFF
--- a/.github/workflows/helio-upstream-watch.yml
+++ b/.github/workflows/helio-upstream-watch.yml
@@ -42,8 +42,17 @@ jobs:
           # sat at v2.3.2-rc2 across three releases, which meant this digest
           # reported long-synced releases as new. `version.inc` records the same
           # fact, is written by the sync merge itself, and needs no permission.
-          BASELINE_TAG="v$(sed -n 's/.*SoftFever_VERSION[[:space:]]*"\([^"]*\)".*/\1/p' version.inc)"
-          if [ "$BASELINE_TAG" = "v" ] || ! git rev-parse -q --verify "$BASELINE_TAG^{commit}" >/dev/null; then
+          # `|| true` and the readability test matter: this step runs under
+          # `bash -e -o pipefail`, so an unreadable version.inc would abort here
+          # and the fallback below — the whole reason it exists — would never
+          # run. `head -1` keeps a second matching line from splicing a newline
+          # into the ref name.
+          BASELINE_VER=""
+          if [ -r version.inc ]; then
+            BASELINE_VER=$(sed -n 's/.*SoftFever_VERSION[[:space:]]*"\([^"]*\)".*/\1/p' version.inc | head -1 || true)
+          fi
+          BASELINE_TAG="v$BASELINE_VER"
+          if [ -z "$BASELINE_VER" ] || ! git rev-parse -q --verify "$BASELINE_TAG^{commit}" >/dev/null; then
             echo "::warning title=Digest baseline unresolved::version.inc yielded '$BASELINE_TAG', which is not an upstream tag. Falling back to v2.3.2-rc2, so this digest will over-report releases as new."
             BASELINE_TAG="v2.3.2-rc2"
           fi

--- a/.github/workflows/helio-upstream-watch.yml
+++ b/.github/workflows/helio-upstream-watch.yml
@@ -52,11 +52,25 @@ jobs:
             BASELINE_VER=$(sed -n 's/.*SoftFever_VERSION[[:space:]]*"\([^"]*\)".*/\1/p' version.inc | head -1 || true)
           fi
           BASELINE_TAG="v$BASELINE_VER"
-          if [ -z "$BASELINE_VER" ] || ! git rev-parse -q --verify "$BASELINE_TAG^{commit}" >/dev/null; then
+          BASELINE_SOURCE="version.inc"
+
+          # Verify through refs/tags/ explicitly. A bare name resolves branches
+          # too, and while git's disambiguation happens to prefer tags over
+          # heads, "happens to" is not what a baseline should rest on — upstream
+          # ships release/* branches alongside these tags.
+          if [ -z "$BASELINE_VER" ] || ! git rev-parse -q --verify "refs/tags/$BASELINE_TAG^{commit}" >/dev/null; then
             echo "::warning title=Digest baseline unresolved::version.inc yielded '$BASELINE_TAG', which is not an upstream tag. Falling back to v2.3.2-rc2, so this digest will over-report releases as new."
             BASELINE_TAG="v2.3.2-rc2"
+            BASELINE_SOURCE="hardcoded fallback"
+            # If even the fallback is absent, stop. Handing an unresolved ref to
+            # the merge-base loop below silently yields a wrong digest, and a
+            # wrong digest is worse than none: it is read as "nothing to sync".
+            if ! git rev-parse -q --verify "refs/tags/$BASELINE_TAG^{commit}" >/dev/null; then
+              echo "::error title=No usable digest baseline::Neither version.inc nor the v2.3.2-rc2 fallback resolves to an upstream tag. Refusing to compute a digest from an unresolved baseline."
+              exit 1
+            fi
           fi
-          echo "Digest baseline: $BASELINE_TAG (from version.inc)"
+          echo "Digest baseline: $BASELINE_TAG (source: $BASELINE_SOURCE)"
 
           # New tags since baseline
           NEW_TAGS=$(git tag -l 'v*' --sort=-version:refname | while read tag; do

--- a/.github/workflows/helio-upstream-watch.yml
+++ b/.github/workflows/helio-upstream-watch.yml
@@ -70,11 +70,16 @@ jobs:
               exit 1
             fi
           fi
+          # Every git operation consuming the baseline goes through this, so
+          # what was verified above is what gets used. BASELINE_TAG stays bare
+          # for the string compare below (it matches `git tag -l` output) and
+          # for display.
+          BASELINE_REF="refs/tags/$BASELINE_TAG"
           echo "Digest baseline: $BASELINE_TAG (source: $BASELINE_SOURCE)"
 
           # New tags since baseline
           NEW_TAGS=$(git tag -l 'v*' --sort=-version:refname | while read tag; do
-            if git merge-base --is-ancestor "$BASELINE_TAG" "$tag" 2>/dev/null && [ "$tag" != "$BASELINE_TAG" ]; then
+            if git merge-base --is-ancestor "$BASELINE_REF" "refs/tags/$tag" 2>/dev/null && [ "$tag" != "$BASELINE_TAG" ]; then
               COMMIT_DATE=$(git log -1 --format='%ci' "$tag" | cut -d' ' -f1)
               echo "- \`$tag\` ($COMMIT_DATE)"
             fi

--- a/.github/workflows/helio-upstream-watch.yml
+++ b/.github/workflows/helio-upstream-watch.yml
@@ -32,16 +32,22 @@ jobs:
         run: |
           RELEASE_BRANCH="${{ vars.HELIO_RELEASE_BRANCH || 'orca-latest-parity-bambu' }}"
 
-          # Find last-synced baseline
-          if git rev-parse "helio-last-synced" >/dev/null 2>&1; then
-            BASELINE_COMMIT=$(git rev-parse "helio-last-synced")
-            BASELINE_TAG=$(git tag -l 'v*' --points-at "$BASELINE_COMMIT" | head -1)
-            if [ -z "$BASELINE_TAG" ]; then
-              BASELINE_TAG="helio-last-synced"
-            fi
-          else
+          # Baseline: the upstream release this branch actually holds.
+          #
+          # This used to read the `helio-last-synced` tag. That tag points at an
+          # UPSTREAM commit, and GitHub refuses to let any App token create or
+          # update a ref that makes upstream's `.github/workflows/**` newly
+          # reachable without the `workflows` permission — which a workflow
+          # cannot grant itself. So the tag has never been movable from CI and
+          # sat at v2.3.2-rc2 across three releases, which meant this digest
+          # reported long-synced releases as new. `version.inc` records the same
+          # fact, is written by the sync merge itself, and needs no permission.
+          BASELINE_TAG="v$(sed -n 's/.*SoftFever_VERSION[[:space:]]*"\([^"]*\)".*/\1/p' version.inc)"
+          if [ "$BASELINE_TAG" = "v" ] || ! git rev-parse -q --verify "$BASELINE_TAG^{commit}" >/dev/null; then
+            echo "::warning title=Digest baseline unresolved::version.inc yielded '$BASELINE_TAG', which is not an upstream tag. Falling back to v2.3.2-rc2, so this digest will over-report releases as new."
             BASELINE_TAG="v2.3.2-rc2"
           fi
+          echo "Digest baseline: $BASELINE_TAG (from version.inc)"
 
           # New tags since baseline
           NEW_TAGS=$(git tag -l 'v*' --sort=-version:refname | while read tag; do


### PR DESCRIPTION
# Description

First step of the decision taken on #111: **drop `helio-last-synced`** rather than issue it a PAT or redefine what it points at.

The tag is unmovable by design, not by misconfiguration. It points at an **upstream** commit, so creating the ref makes upstream's `.github/workflows/**` newly reachable, and GitHub refuses that to any App token without the `workflows` permission — which a workflow cannot grant itself. It has never advanced from CI, and sat at `v2.3.2-rc2` across three releases.

## Why watch has to move first

Checking for other readers before deleting anything turned one up: **`helio-upstream-watch.yml` reads this tag too**, and it fails in a way nobody would notice from the outside.

The tag currently points at `6187063190`, which carries no `v*` tag. So the lookup fell through to `BASELINE_TAG="helio-last-synced"` — the literal string — and every upstream release after that commit was reported as **new**, on every run. The digest has been over-reporting rather than erroring, which is why it went unremarked.

`version.inc` records the same fact, is written by the sync merge itself, and needs no permission to update.

## Verified against the real repository, not reasoned

| | result |
| --- | --- |
| baseline derived from `version.inc` | `v2.4.2` |
| does it resolve | yes |
| releases the digest now reports as new | **none** — correct, we are synced to the newest |
| under the old tag path | falls through to the literal `helio-last-synced`, over-reporting |

An unresolvable `version.inc` warns and falls back to the previous hardcoded baseline rather than failing the run: a noisy digest beats a broken one.

## Scope

**`helio-last-synced-main` is deliberately untouched.** For `main`-mode syncs it is the only baseline there is — `version.inc` names a tagged release and cannot identify an untagged `main` commit — so it needs its own decision rather than being swept along with this one. It has the same permission problem, which means `main`-mode syncs are already degraded; worth knowing, not worth conflating.

## Sequencing

This PR removes one of the two readers. The rest of the removal — the sync workflow's own reads and writes, and deleting the two remote refs — waits for **#111**, which rewrites large parts of `helio-upstream-sync.yml`; doing it now would guarantee a conflict for no gain. This file is untouched by #111 (verified with `git diff` against its branch), so this piece lands independently.

Remaining after this:
1. #111 merges.
2. Remove the tag read/write from `helio-upstream-sync.yml`.
3. `git push helio :refs/tags/helio-last-synced` to delete the ref.

# Screenshots/Recordings/Graphs

N/A — CI workflow logic.

## Tests

The digest logic was executed against this repository, both paths, with the results in the table above. The workflow YAML re-parses. Not covered: the workflow has not run on Actions with this change — the step body was extracted and run locally, and `version.inc` is present in the checkout the job already performs.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0181jdoWcjHRDKQDiHj512i4

---
_Generated by [Claude Code](https://claude.ai/code/session_0181jdoWcjHRDKQDiHj512i4)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved upstream update tracking by selecting the correct recorded version as the comparison baseline.
  * Added validation for missing, unreadable, or invalid baseline information.
  * Added a reliable fallback version when the recorded baseline is unavailable.
  * Improved diagnostic logging and error handling when no valid baseline can be found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the stale `helio-last-synced` baseline used by the upstream-watch digest with the upstream release recorded in `version.inc`.
- Parses and validates the recorded upstream version before comparing release tags.
- Warns and falls back to `v2.3.2-rc2` when the recorded baseline cannot be resolved.
- Leaves the separate main-sync baseline unchanged.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/helio-upstream-watch.yml | Derives the release-digest baseline from `version.inc`, validates the resulting tag, and retains a warning fallback for unresolved values. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Make the baseline fallback actually reac..."](https://github.com/helio-additive/orcaslicer/commit/6802cc34dee29b202fd7d5a0bd73f49c40aad664) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54276151)</sub>

<!-- /greptile_comment -->