### PR TITLE
Add warpage simulation fields and viewer visualizations (parse, store, expose views)

### DIFF
--- a/src/libslic3r/GCode/GCodeProcessor.cpp
+++ b/src/libslic3r/GCode/GCodeProcessor.cpp
@@ -1686,6 +1686,9 @@ void GCodeProcessorResult::reset() {
     filament_change_count_map.clear();
     warnings.clear();
     is_helio_gcode = false;
+    warpage_shrinkage_x_pct = warpage_shrinkage_y_pct = warpage_shrinkage_z_pct = NAN;
+    warpage_max_displacement_mm = warpage_max_hull_shrinkage_um = NAN;
+    warpage_wdm_p95 = warpage_whs_p95 = NAN;
 
     //BBS: add mutex for protection of gcode result
     unlock();
@@ -3164,6 +3167,22 @@ void GCodeProcessor::process_tags(const std::string_view comment, bool producers
     }
 
     // Helio thermal index: handled in process_G1() to ensure parsing occurs before vertex storage
+    const auto parse_warpage_header = [&comment](const std::string_view prefix, float& target) {
+        if (!boost::starts_with(comment, prefix))
+            return false;
+        try {
+            target = static_cast<float>(string_to_double_decimal_point(std::string(comment.substr(prefix.size()))));
+        } catch (...) {}
+        return true;
+    };
+    if (parse_warpage_header(" WARPAGE_SHRINKAGE_X_PCT=", m_result.warpage_shrinkage_x_pct) ||
+        parse_warpage_header(" WARPAGE_SHRINKAGE_Y_PCT=", m_result.warpage_shrinkage_y_pct) ||
+        parse_warpage_header(" WARPAGE_SHRINKAGE_Z_PCT=", m_result.warpage_shrinkage_z_pct) ||
+        parse_warpage_header(" WARPAGE_MAX_DISPLACEMENT_MM=", m_result.warpage_max_displacement_mm) ||
+        parse_warpage_header(" WARPAGE_MAX_HULL_SHRINKAGE_UM=", m_result.warpage_max_hull_shrinkage_um) ||
+        parse_warpage_header(" WARPAGE_WDM_P95=", m_result.warpage_wdm_p95) ||
+        parse_warpage_header(" WARPAGE_WHS_P95=", m_result.warpage_whs_p95))
+        return;
 
     // wipe start tag
     if (boost::starts_with(comment, reserved_tag(ETags::Wipe_Start))) {
@@ -3839,6 +3858,7 @@ void GCodeProcessor::process_G1(const GCodeReader::GCodeLine& line, const std::o
     m_thermal_index_mean = -200.0f;
     m_thermal_index_min = -200.0f;
     m_thermal_index_max = -200.0f;
+    m_warpage_fields.fill(NAN);
     {
         const std::string& raw = line.raw();
         auto pos = raw.find(";helioadditive=");
@@ -3851,6 +3871,12 @@ void GCodeProcessor::process_G1(const GCodeReader::GCodeLine& line, const std::o
                 m_thermal_index_min = static_cast<float>(std::atof(match[2].str().c_str())) * 100.0f;
                 m_thermal_index_mean = static_cast<float>(std::atof(match[3].str().c_str())) * 100.0f;
                 m_is_helio_gcode = true;
+            }
+            const std::array<const char*, 9> keys = { "wdm", "wdx", "wdy", "wdz", "wr", "wtg", "wts", "whs", "wls" };
+            for (size_t i = 0; i < keys.size(); ++i) {
+                const std::regex field_re(std::string("(?:^|,)") + keys[i] + "=(-?[0-9]*\\.?[0-9]+)");
+                if (std::regex_search(comment_str, match, field_re))
+                    m_warpage_fields[i] = static_cast<float>(std::atof(match[1].str().c_str()));
             }
         }
     }
@@ -4595,6 +4621,7 @@ void GCodeProcessor::process_G2_G3(const GCodeReader::GCodeLine& line, bool cloc
     m_thermal_index_mean = -200.0f;
     m_thermal_index_min = -200.0f;
     m_thermal_index_max = -200.0f;
+    m_warpage_fields.fill(NAN);
     {
         const std::string& raw = line.raw();
         auto pos = raw.find(";helioadditive=");
@@ -4607,6 +4634,12 @@ void GCodeProcessor::process_G2_G3(const GCodeReader::GCodeLine& line, bool cloc
                 m_thermal_index_min = static_cast<float>(std::atof(match[2].str().c_str())) * 100.0f;
                 m_thermal_index_mean = static_cast<float>(std::atof(match[3].str().c_str())) * 100.0f;
                 m_is_helio_gcode = true;
+            }
+            const std::array<const char*, 9> keys = { "wdm", "wdx", "wdy", "wdz", "wr", "wtg", "wts", "whs", "wls" };
+            for (size_t i = 0; i < keys.size(); ++i) {
+                const std::regex field_re(std::string("(?:^|,)") + keys[i] + "=(-?[0-9]*\\.?[0-9]+)");
+                if (std::regex_search(comment_str, match, field_re))
+                    m_warpage_fields[i] = static_cast<float>(std::atof(match[1].str().c_str()));
             }
         }
     }
@@ -5761,6 +5794,15 @@ void GCodeProcessor::store_move_vertex(EMoveType type, EMovePathType path_type, 
         m_thermal_index_mean,
         m_thermal_index_min,
         m_thermal_index_max,
+        m_warpage_fields[0],
+        m_warpage_fields[1],
+        m_warpage_fields[2],
+        m_warpage_fields[3],
+        m_warpage_fields[4],
+        m_warpage_fields[5],
+        m_warpage_fields[6],
+        m_warpage_fields[7],
+        m_warpage_fields[8],
         { 0.0f, 0.0f }, // time
         static_cast<float>(m_layer_id), //layer_duration: set later
         std::max<unsigned int>(1, m_layer_id) - 1,

--- a/src/libslic3r/GCode/GCodeProcessor.hpp
+++ b/src/libslic3r/GCode/GCodeProcessor.hpp
@@ -14,6 +14,7 @@
 #include <string>
 #include <string_view>
 #include <optional>
+#include <cmath>
 
 namespace Slic3r {
 
@@ -171,6 +172,13 @@ class Print;
         FilamentPrintableResult filament_printable_reuslt;
         float initial_layer_time;
         bool is_helio_gcode{false};
+        float warpage_shrinkage_x_pct{ NAN };
+        float warpage_shrinkage_y_pct{ NAN };
+        float warpage_shrinkage_z_pct{ NAN };
+        float warpage_max_displacement_mm{ NAN };
+        float warpage_max_hull_shrinkage_um{ NAN };
+        float warpage_wdm_p95{ NAN };
+        float warpage_whs_p95{ NAN };
 
         struct SettingsIds
         {
@@ -212,6 +220,15 @@ class Print;
             float thermal_index_mean{ -200.0f };
             float thermal_index_min{ -200.0f };
             float thermal_index_max{ -200.0f };
+            float warpage_displacement{ NAN };
+            float warpage_disp_x{ NAN };
+            float warpage_disp_y{ NAN };
+            float warpage_disp_z{ NAN };
+            float warpage_risk{ NAN };
+            float warpage_ti_gradient{ NAN };
+            float warpage_thermal_strain{ NAN };
+            float warpage_hull_shrinkage{ NAN };
+            float warpage_layer_shrinkage{ NAN };
             std::array<float, static_cast<size_t>(PrintEstimatedStatistics::ETimeMode::Count)> time{ 0.0f, 0.0f }; // s
             float layer_duration{ 0.0f }; // s
             unsigned int layer_id{ 0 };
@@ -319,6 +336,13 @@ class Print;
             filament_change_count_map = other.filament_change_count_map;
             initial_layer_time = other.initial_layer_time;
             is_helio_gcode = other.is_helio_gcode;
+            warpage_shrinkage_x_pct = other.warpage_shrinkage_x_pct;
+            warpage_shrinkage_y_pct = other.warpage_shrinkage_y_pct;
+            warpage_shrinkage_z_pct = other.warpage_shrinkage_z_pct;
+            warpage_max_displacement_mm = other.warpage_max_displacement_mm;
+            warpage_max_hull_shrinkage_um = other.warpage_max_hull_shrinkage_um;
+            warpage_wdm_p95 = other.warpage_wdm_p95;
+            warpage_whs_p95 = other.warpage_whs_p95;
 #if ENABLE_GCODE_VIEWER_STATISTICS
             time = other.time;
 #endif
@@ -835,6 +859,7 @@ class Print;
         float m_thermal_index_mean{ -200.0f };
         float m_thermal_index_min{ -200.0f };
         float m_thermal_index_max{ -200.0f };
+        std::array<float, 9> m_warpage_fields{ NAN, NAN, NAN, NAN, NAN, NAN, NAN, NAN, NAN };
         bool m_is_helio_gcode{false};
         ExtrusionRole m_extrusion_role;
         std::vector<int> m_filament_maps;
@@ -1170,5 +1195,3 @@ class Print;
 } /* namespace Slic3r */
 
 #endif /* slic3r_GCodeProcessor_hpp_ */
-
-

--- a/src/libvgcode/include/PathVertex.hpp
+++ b/src/libvgcode/include/PathVertex.hpp
@@ -8,6 +8,7 @@
 #include "Types.hpp"
 
 #include <cfloat>
+#include <cmath>
 
 namespace libvgcode {
 
@@ -106,6 +107,15 @@ struct PathVertex
     float thermal_index_mean{ -200.0f };
     float thermal_index_min{ -200.0f };
     float thermal_index_max{ -200.0f };
+    float warpage_displacement{ NAN };
+    float warpage_disp_x{ NAN };
+    float warpage_disp_y{ NAN };
+    float warpage_disp_z{ NAN };
+    float warpage_risk{ NAN };
+    float warpage_ti_gradient{ NAN };
+    float warpage_thermal_strain{ NAN };
+    float warpage_hull_shrinkage{ NAN };
+    float warpage_layer_shrinkage{ NAN };
 
     //
     // Return true if the segment is an extrusion move

--- a/src/libvgcode/include/Types.hpp
+++ b/src/libvgcode/include/Types.hpp
@@ -102,6 +102,15 @@ enum class EViewType : uint8_t
     ThermalIndexMean,
     ThermalIndexMin,
     ThermalIndexMax,
+    WarpageDisplacement,
+    WarpageDispX,
+    WarpageDispY,
+    WarpageDispZ,
+    WarpageRisk,
+    WarpageTIGradient,
+    WarpageThermalStrain,
+    WarpageHullShrinkage,
+    WarpageLayerShrinkage,
     Tool,
     COUNT
 };

--- a/src/libvgcode/src/ViewerImpl.cpp
+++ b/src/libvgcode/src/ViewerImpl.cpp
@@ -1536,6 +1536,15 @@ Color ViewerImpl::get_vertex_color(const PathVertex& v) const
         if (v.thermal_index_max < -100.0f) return DUMMY_COLOR;
         return m_thermal_index_max_range.get_color_at(v.thermal_index_max);
     }
+    case EViewType::WarpageDisplacement: return std::isnan(v.warpage_displacement) ? DUMMY_COLOR : m_warpage_ranges[0].get_color_at(v.warpage_displacement);
+    case EViewType::WarpageDispX: return std::isnan(v.warpage_disp_x) ? DUMMY_COLOR : m_warpage_ranges[1].get_color_at(v.warpage_disp_x);
+    case EViewType::WarpageDispY: return std::isnan(v.warpage_disp_y) ? DUMMY_COLOR : m_warpage_ranges[2].get_color_at(v.warpage_disp_y);
+    case EViewType::WarpageDispZ: return std::isnan(v.warpage_disp_z) ? DUMMY_COLOR : m_warpage_ranges[3].get_color_at(v.warpage_disp_z);
+    case EViewType::WarpageRisk: return std::isnan(v.warpage_risk) ? DUMMY_COLOR : m_warpage_ranges[4].get_color_at(v.warpage_risk);
+    case EViewType::WarpageTIGradient: return std::isnan(v.warpage_ti_gradient) ? DUMMY_COLOR : m_warpage_ranges[5].get_color_at(v.warpage_ti_gradient);
+    case EViewType::WarpageThermalStrain: return std::isnan(v.warpage_thermal_strain) ? DUMMY_COLOR : m_warpage_ranges[6].get_color_at(v.warpage_thermal_strain);
+    case EViewType::WarpageHullShrinkage: return std::isnan(v.warpage_hull_shrinkage) ? DUMMY_COLOR : m_warpage_ranges[7].get_color_at(v.warpage_hull_shrinkage);
+    case EViewType::WarpageLayerShrinkage: return std::isnan(v.warpage_layer_shrinkage) ? DUMMY_COLOR : m_warpage_ranges[8].get_color_at(v.warpage_layer_shrinkage);
     case EViewType::VolumetricFlowRate:
     {
         return v.is_travel() ? get_option_color(move_type_to_option(v.type)) : m_volumetric_rate_range.get_color_at(v.volumetric_rate());
@@ -1634,6 +1643,15 @@ const ColorRange& ViewerImpl::get_color_range(EViewType type) const
     case EViewType::ThermalIndexMean:         { return m_thermal_index_mean_range; }
     case EViewType::ThermalIndexMin:          { return m_thermal_index_min_range; }
     case EViewType::ThermalIndexMax:          { return m_thermal_index_max_range; }
+    case EViewType::WarpageDisplacement: return m_warpage_ranges[0];
+    case EViewType::WarpageDispX: return m_warpage_ranges[1];
+    case EViewType::WarpageDispY: return m_warpage_ranges[2];
+    case EViewType::WarpageDispZ: return m_warpage_ranges[3];
+    case EViewType::WarpageRisk: return m_warpage_ranges[4];
+    case EViewType::WarpageTIGradient: return m_warpage_ranges[5];
+    case EViewType::WarpageThermalStrain: return m_warpage_ranges[6];
+    case EViewType::WarpageHullShrinkage: return m_warpage_ranges[7];
+    case EViewType::WarpageLayerShrinkage: return m_warpage_ranges[8];
     case EViewType::VolumetricFlowRate:       { return m_volumetric_rate_range; }
     case EViewType::ActualVolumetricFlowRate: { return m_actual_volumetric_rate_range; }
     case EViewType::LayerTimeLinear:          { return m_layer_time_range[0]; }
@@ -1661,6 +1679,15 @@ void ViewerImpl::set_color_range_palette(EViewType type, const Palette& palette)
     case EViewType::ThermalIndexMean:         { m_thermal_index_mean_range.set_palette(palette); break; }
     case EViewType::ThermalIndexMin:          { m_thermal_index_min_range.set_palette(palette); break; }
     case EViewType::ThermalIndexMax:          { m_thermal_index_max_range.set_palette(palette); break; }
+    case EViewType::WarpageDisplacement: m_warpage_ranges[0].set_palette(palette); break;
+    case EViewType::WarpageDispX: m_warpage_ranges[1].set_palette(palette); break;
+    case EViewType::WarpageDispY: m_warpage_ranges[2].set_palette(palette); break;
+    case EViewType::WarpageDispZ: m_warpage_ranges[3].set_palette(palette); break;
+    case EViewType::WarpageRisk: m_warpage_ranges[4].set_palette(palette); break;
+    case EViewType::WarpageTIGradient: m_warpage_ranges[5].set_palette(palette); break;
+    case EViewType::WarpageThermalStrain: m_warpage_ranges[6].set_palette(palette); break;
+    case EViewType::WarpageHullShrinkage: m_warpage_ranges[7].set_palette(palette); break;
+    case EViewType::WarpageLayerShrinkage: m_warpage_ranges[8].set_palette(palette); break;
     case EViewType::VolumetricFlowRate:       { m_volumetric_rate_range.set_palette(palette); break; }
     case EViewType::ActualVolumetricFlowRate: { m_actual_volumetric_rate_range.set_palette(palette); break; }
     case EViewType::LayerTimeLinear:          { m_layer_time_range[0].set_palette(palette);   break; }
@@ -1707,6 +1734,8 @@ size_t ViewerImpl::get_used_cpu_memory() const
     ret += m_thermal_index_mean_range.size_in_bytes_cpu();
     ret += m_thermal_index_min_range.size_in_bytes_cpu();
     ret += m_thermal_index_max_range.size_in_bytes_cpu();
+    for (const ColorRange& range : m_warpage_ranges)
+        ret += range.size_in_bytes_cpu();
     ret += m_volumetric_rate_range.size_in_bytes_cpu();
     ret += m_actual_volumetric_rate_range.size_in_bytes_cpu();
     for (size_t i = 0; i < COLOR_RANGE_TYPES_COUNT; ++i) {
@@ -1866,6 +1895,8 @@ void ViewerImpl::update_color_ranges()
     m_thermal_index_mean_range.reset();
     m_thermal_index_min_range.reset();
     m_thermal_index_max_range.reset();
+    for (ColorRange& range : m_warpage_ranges)
+        range.reset();
     // Helio: Use custom TI palette (blue→green→red) matching BambuStudio
     static const Palette TI_PALETTE{ {
         {  11,  44, 122 },  // #0b2c7a  -100 (blue)
@@ -1883,6 +1914,17 @@ void ViewerImpl::update_color_ranges()
     m_thermal_index_mean_range.set_palette(TI_PALETTE);
     m_thermal_index_min_range.set_palette(TI_PALETTE);
     m_thermal_index_max_range.set_palette(TI_PALETTE);
+    static const Palette WARPAGE_SEQUENTIAL{ {
+        { 30, 180, 60 }, { 140, 190, 40 }, { 220, 180, 30 }, { 230, 100, 20 }, { 200, 20, 20 }
+    } };
+    static const Palette WARPAGE_DIVERGING{ { { 0, 60, 200 }, { 30, 180, 60 }, { 200, 20, 20 } } };
+    static const Palette WARPAGE_DARK{ { { 25, 30, 50 }, { 30, 160, 60 }, { 220, 180, 30 }, { 200, 20, 20 } } };
+    for (ColorRange& range : m_warpage_ranges)
+        range.set_palette(WARPAGE_SEQUENTIAL);
+    m_warpage_ranges[1].set_palette(WARPAGE_DIVERGING);
+    m_warpage_ranges[2].set_palette(WARPAGE_DIVERGING);
+    m_warpage_ranges[3].set_palette(WARPAGE_DIVERGING);
+    m_warpage_ranges[7].set_palette(WARPAGE_DARK);
     // Anchor to fixed [-100, +100] so colors always match the legend
     m_thermal_index_mean_range.update(-100.0f);
     m_thermal_index_mean_range.update(100.0f);
@@ -1916,6 +1958,12 @@ void ViewerImpl::update_color_ranges()
                 m_thermal_index_min_range.update(v.thermal_index_min);
             if (v.thermal_index_max > -100.0f)
                 m_thermal_index_max_range.update(v.thermal_index_max);
+            const std::array<float, 9> warpage_values = { v.warpage_displacement, v.warpage_disp_x, v.warpage_disp_y,
+                v.warpage_disp_z, v.warpage_risk, v.warpage_ti_gradient, v.warpage_thermal_strain,
+                v.warpage_hull_shrinkage, v.warpage_layer_shrinkage };
+            for (size_t j = 0; j < warpage_values.size(); ++j)
+                if (!std::isnan(warpage_values[j]))
+                    m_warpage_ranges[j].update(warpage_values[j]);
         }
         if ((v.is_travel() && m_settings.options_visibility[size_t(EOptionType::Travels)]) ||
             (v.is_wipe() && m_settings.options_visibility[size_t(EOptionType::Wipes)]) ||

--- a/src/libvgcode/src/ViewerImpl.hpp
+++ b/src/libvgcode/src/ViewerImpl.hpp
@@ -299,6 +299,7 @@ private:
     ColorRange m_thermal_index_mean_range;
     ColorRange m_thermal_index_min_range;
     ColorRange m_thermal_index_max_range;
+    std::array<ColorRange, 9> m_warpage_ranges;
     ColorRange m_volumetric_rate_range;
     ColorRange m_actual_volumetric_rate_range;
     std::array<ColorRange, COLOR_RANGE_TYPES_COUNT> m_layer_time_range{

--- a/src/slic3r/GUI/GCodeViewer.cpp
+++ b/src/slic3r/GUI/GCodeViewer.cpp
@@ -107,6 +107,15 @@ static std::string get_view_type_string(libvgcode::EViewType view_type)
         return _u8L("Thermal Index (min)");
     else if (view_type == libvgcode::EViewType::ThermalIndexMax)
         return _u8L("Thermal Index (max)");
+    else if (view_type == libvgcode::EViewType::WarpageDisplacement) return _u8L("Warpage displacement");
+    else if (view_type == libvgcode::EViewType::WarpageDispX) return _u8L("Warpage displacement X");
+    else if (view_type == libvgcode::EViewType::WarpageDispY) return _u8L("Warpage displacement Y");
+    else if (view_type == libvgcode::EViewType::WarpageDispZ) return _u8L("Warpage displacement Z");
+    else if (view_type == libvgcode::EViewType::WarpageRisk) return _u8L("Warpage risk");
+    else if (view_type == libvgcode::EViewType::WarpageTIGradient) return _u8L("Warpage TI gradient");
+    else if (view_type == libvgcode::EViewType::WarpageThermalStrain) return _u8L("Warpage thermal strain");
+    else if (view_type == libvgcode::EViewType::WarpageHullShrinkage) return _u8L("Warpage hull shrinkage");
+    else if (view_type == libvgcode::EViewType::WarpageLayerShrinkage) return _u8L("Warpage layer shrinkage");
     return "";
 }
 
@@ -1195,6 +1204,17 @@ void GCodeViewer::update_by_mode(ConfigOptionMode mode)
         view_type_items.push_back(libvgcode::EViewType::ThermalIndexMin);
         view_type_items.push_back(libvgcode::EViewType::ThermalIndexMax);
     }
+    if (m_has_warpage_data) {
+        view_type_items.push_back(libvgcode::EViewType::WarpageDisplacement);
+        view_type_items.push_back(libvgcode::EViewType::WarpageDispX);
+        view_type_items.push_back(libvgcode::EViewType::WarpageDispY);
+        view_type_items.push_back(libvgcode::EViewType::WarpageDispZ);
+        view_type_items.push_back(libvgcode::EViewType::WarpageRisk);
+        view_type_items.push_back(libvgcode::EViewType::WarpageTIGradient);
+        view_type_items.push_back(libvgcode::EViewType::WarpageThermalStrain);
+        view_type_items.push_back(libvgcode::EViewType::WarpageHullShrinkage);
+        view_type_items.push_back(libvgcode::EViewType::WarpageLayerShrinkage);
+    }
     //if (mode == ConfigOptionMode::comDevelop) {
     //    view_type_items.push_back(EViewType::Tool);
     //}
@@ -1375,15 +1395,17 @@ void GCodeViewer::load_as_gcode(const GCodeProcessorResult& gcode_result, const 
     m_viewer.reset_default_extrusion_roles_colors();
     m_viewer.load(std::move(data));
 
-    // Helio: detect whether this gcode has any thermal index data
+    // Helio: expose simulation-only views only when their data is present.
     m_has_thermal_index_data = false;
+    m_has_warpage_data = false;
     {
         const size_t vcount = m_viewer.get_vertices_count();
         for (size_t i = 0; i < vcount; ++i) {
-            if (m_viewer.get_vertex_at(i).thermal_index_mean > -100.0f) {
-                m_has_thermal_index_data = true;
+            const libvgcode::PathVertex& vertex = m_viewer.get_vertex_at(i);
+            m_has_thermal_index_data |= vertex.thermal_index_mean > -100.0f;
+            m_has_warpage_data |= !std::isnan(vertex.warpage_displacement);
+            if (m_has_thermal_index_data && m_has_warpage_data)
                 break;
-            }
         }
     }
     update_by_mode(wxGetApp().get_mode());
@@ -1678,15 +1700,17 @@ void GCodeViewer::load_as_preview(libvgcode::GCodeInputData&& data)
     m_viewer.set_extrusion_role_color(libvgcode::EGCodeExtrusionRole::WipeTower,                { 127, 255, 127 });
     m_viewer.load(std::move(data));
 
-    // Helio: detect whether this gcode has any thermal index data
+    // Helio: expose simulation-only views only when their data is present.
     m_has_thermal_index_data = false;
+    m_has_warpage_data = false;
     {
         const size_t vcount = m_viewer.get_vertices_count();
         for (size_t i = 0; i < vcount; ++i) {
-            if (m_viewer.get_vertex_at(i).thermal_index_mean > -100.0f) {
-                m_has_thermal_index_data = true;
+            const libvgcode::PathVertex& vertex = m_viewer.get_vertex_at(i);
+            m_has_thermal_index_data |= vertex.thermal_index_mean > -100.0f;
+            m_has_warpage_data |= !std::isnan(vertex.warpage_displacement);
+            if (m_has_thermal_index_data && m_has_warpage_data)
                 break;
-            }
         }
     }
     update_by_mode(wxGetApp().get_mode());
@@ -3892,6 +3916,15 @@ void GCodeViewer::render_legend(float &legend_height, int canvas_width, int canv
         { imgui.title(_u8L("Thermal Index (min)")); break; }
     case libvgcode::EViewType::ThermalIndexMax:
         { imgui.title(_u8L("Thermal Index (max)")); break; }
+    case libvgcode::EViewType::WarpageDisplacement: { imgui.title(_u8L("Warpage displacement (mm)")); break; }
+    case libvgcode::EViewType::WarpageDispX: { imgui.title(_u8L("Warpage displacement X (mm)")); break; }
+    case libvgcode::EViewType::WarpageDispY: { imgui.title(_u8L("Warpage displacement Y (mm)")); break; }
+    case libvgcode::EViewType::WarpageDispZ: { imgui.title(_u8L("Warpage displacement Z (mm)")); break; }
+    case libvgcode::EViewType::WarpageRisk: { imgui.title(_u8L("Warpage risk")); break; }
+    case libvgcode::EViewType::WarpageTIGradient: { imgui.title(_u8L("Warpage TI gradient")); break; }
+    case libvgcode::EViewType::WarpageThermalStrain: { imgui.title(_u8L("Warpage thermal strain")); break; }
+    case libvgcode::EViewType::WarpageHullShrinkage: { imgui.title(_u8L("Warpage hull shrinkage")); break; }
+    case libvgcode::EViewType::WarpageLayerShrinkage: { imgui.title(_u8L("Warpage layer shrinkage")); break; }
 
     case libvgcode::EViewType::Tool:
     {
@@ -4221,6 +4254,17 @@ void GCodeViewer::render_legend(float &legend_height, int canvas_width, int canv
 
         break;
     }
+    case libvgcode::EViewType::WarpageDisplacement:
+    case libvgcode::EViewType::WarpageDispX:
+    case libvgcode::EViewType::WarpageDispY:
+    case libvgcode::EViewType::WarpageDispZ:
+    case libvgcode::EViewType::WarpageRisk:
+    case libvgcode::EViewType::WarpageTIGradient:
+    case libvgcode::EViewType::WarpageThermalStrain:
+    case libvgcode::EViewType::WarpageHullShrinkage:
+    case libvgcode::EViewType::WarpageLayerShrinkage:
+        append_range(m_viewer.get_color_range(curr_view_type), 4);
+        break;
     case libvgcode::EViewType::Tool:
     {
         // shows only extruders actually used
@@ -4953,4 +4997,3 @@ void GCodeViewer::render_slider(int canvas_width, int canvas_height) {
 
 } // namespace GUI
 } // namespace Slic3r
-

--- a/src/slic3r/GUI/GCodeViewer.hpp
+++ b/src/slic3r/GUI/GCodeViewer.hpp
@@ -253,6 +253,7 @@ mutable bool m_no_render_path { false };
     libvgcode::Viewer m_viewer;
     bool m_loaded_as_preview{ false };
     bool m_has_thermal_index_data{ false };
+    bool m_has_warpage_data{ false };
 
 public:
     GCodeViewer();
@@ -384,4 +385,3 @@ private:
 } // namespace Slic3r
 
 #endif // slic3r_GCodeViewer_hpp_
-

--- a/src/slic3r/GUI/LibVGCode/LibVGCodeWrapper.cpp
+++ b/src/slic3r/GUI/LibVGCode/LibVGCodeWrapper.cpp
@@ -228,7 +228,9 @@ GCodeInputData convert(const Slic3r::GCodeProcessorResult& result, const std::ve
                     /* ORCA: Add Pressure Advance visualization support */ 0.0f, curr.pressure_advance,
                     /* ORCA: Add Acceleration visualization support */ curr.acceleration,
                     /* ORCA: Add Jerk visualization support */ curr.jerk,
-            /* Helio: Thermal index from simulation */ curr.thermal_index_mean, curr.thermal_index_min, curr.thermal_index_max };
+            /* Helio: Thermal index from simulation */ curr.thermal_index_mean, curr.thermal_index_min, curr.thermal_index_max,
+            curr.warpage_displacement, curr.warpage_disp_x, curr.warpage_disp_y, curr.warpage_disp_z, curr.warpage_risk,
+            curr.warpage_ti_gradient, curr.warpage_thermal_strain, curr.warpage_hull_shrinkage, curr.warpage_layer_shrinkage };
 #else
               const libvgcode::PathVertex vertex = { convert(prev.position), curr.height, curr.width, curr.feedrate, prev.actual_feedrate,
                     curr.mm3_per_mm, curr.fan_speed, curr.temperature, convert(curr.extrusion_role), curr_type,
@@ -237,7 +239,9 @@ GCodeInputData convert(const Slic3r::GCodeProcessorResult& result, const std::ve
                     /* ORCA: Add Pressure Advance visualization support */ 0.0f, curr.pressure_advance,
                     /* ORCA: Add Acceleration visualization support */ curr.acceleration,
                     /* ORCA: Add Jerk visualization support */ curr.jerk,
-            /* Helio: Thermal index from simulation */ curr.thermal_index_mean, curr.thermal_index_min, curr.thermal_index_max };
+            /* Helio: Thermal index from simulation */ curr.thermal_index_mean, curr.thermal_index_min, curr.thermal_index_max,
+            curr.warpage_displacement, curr.warpage_disp_x, curr.warpage_disp_y, curr.warpage_disp_z, curr.warpage_risk,
+            curr.warpage_ti_gradient, curr.warpage_thermal_strain, curr.warpage_hull_shrinkage, curr.warpage_layer_shrinkage };
 #endif // VGCODE_ENABLE_COG_AND_TOOL_MARKERS
                 ret.vertices.emplace_back(vertex);
             }
@@ -252,7 +256,9 @@ GCodeInputData convert(const Slic3r::GCodeProcessorResult& result, const std::ve
             /* ORCA: Add Pressure Advance visualization support */ 0.0f, curr.pressure_advance,
             /* ORCA: Add Acceleration visualization support */ curr.acceleration,
             /* ORCA: Add Jerk visualization support */ curr.jerk,
-            /* Helio: Thermal index from simulation */ curr.thermal_index_mean, curr.thermal_index_min, curr.thermal_index_max };
+            /* Helio: Thermal index from simulation */ curr.thermal_index_mean, curr.thermal_index_min, curr.thermal_index_max,
+            curr.warpage_displacement, curr.warpage_disp_x, curr.warpage_disp_y, curr.warpage_disp_z, curr.warpage_risk,
+            curr.warpage_ti_gradient, curr.warpage_thermal_strain, curr.warpage_hull_shrinkage, curr.warpage_layer_shrinkage };
 #else
         const libvgcode::PathVertex vertex = { convert(curr.position), curr.height, curr.width, curr.feedrate, curr.actual_feedrate,
             curr.mm3_per_mm, curr.fan_speed, curr.temperature, convert(curr.extrusion_role), curr_type,
@@ -261,7 +267,9 @@ GCodeInputData convert(const Slic3r::GCodeProcessorResult& result, const std::ve
             /* ORCA: Add Pressure Advance visualization support */ 0.0f, curr.pressure_advance,
             /* ORCA: Add Acceleration visualization support */ curr.acceleration,
             /* ORCA: Add Jerk visualization support */ curr.jerk,
-            /* Helio: Thermal index from simulation */ curr.thermal_index_mean, curr.thermal_index_min, curr.thermal_index_max };
+            /* Helio: Thermal index from simulation */ curr.thermal_index_mean, curr.thermal_index_min, curr.thermal_index_max,
+            curr.warpage_displacement, curr.warpage_disp_x, curr.warpage_disp_y, curr.warpage_disp_z, curr.warpage_risk,
+            curr.warpage_ti_gradient, curr.warpage_thermal_strain, curr.warpage_hull_shrinkage, curr.warpage_layer_shrinkage };
 #endif // VGCODE_ENABLE_COG_AND_TOOL_MARKERS
         ret.vertices.emplace_back(vertex);
     }
@@ -834,4 +842,3 @@ GCodeInputData convert(const Slic3r::Print& print, const std::vector<std::string
 }
 
 } // namespace libvgcode
-


### PR DESCRIPTION
### Motivation
- Expose warpage simulation results embedded in G-code (Helio/warpage fields) so they can be visualized in the toolpath viewer. 
- Store per-move warpage metrics alongside existing thermal index values to enable color-mapped inspection and diagnostics. 
- Provide viewer-side color ranges and UI entries so warpage-related views are only shown when data is present.

### Description
- Parse `WARPAGE_*` header tags and `;helioadditive=` warpage key/value pairs in `GCodeProcessor::process_tags` and `process_G1`/`G2/G3`, storing them into `m_result` and `m_warpage_fields`. 
- Add warpage metric members to `GCodeProcessorResult` and `MoveVertex` (fields like `warpage_displacement`, `warpage_disp_x`, `warpage_risk`, etc.) and initialize them to `NAN` when appropriate. 
- Extend libvgcode structures (`PathVertex`, `Types::EViewType`) and the conversion layer (`LibVGCodeWrapper::convert`) to carry the new warpage values through to the viewer. 
- Implement viewer-side support in `ViewerImpl` and `GCodeViewer` including a `std::array<ColorRange,9> m_warpage_ranges`, color mapping for each new `EViewType`, palettes, legend titles, and logic to only show warpage views when `m_has_warpage_data` is detected. 

### Testing
- Project was compiled to verify integration of new fields and headers; compilation succeeded. 
- The viewer was exercised to confirm warpage views appear when at least one vertex contains warpage data and remain hidden otherwise. 
- No new automated unit tests were added in this change and existing test suites were not modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8d2ef4472c832bb741e9506d842157)