### PR TITLE
Add Helio warpage metrics parsing and visualization support

### DIFF
--- a/src/libslic3r/GCode/GCodeProcessor.cpp
+++ b/src/libslic3r/GCode/GCodeProcessor.cpp
@@ -3163,7 +3163,8 @@ void GCodeProcessor::process_tags(const std::string_view comment, bool producers
         return;
     }
 
-    // Helio thermal index: handled in process_G1() to ensure parsing occurs before vertex storage
+    // Helio simulation data is handled while processing moves so it is attached
+    // to the corresponding viewer vertex.
 
     // wipe start tag
     if (boost::starts_with(comment, reserved_tag(ETags::Wipe_Start))) {
@@ -3827,6 +3828,27 @@ bool GCodeProcessor::detect_producer(const std::string_view comment)
     return false;
 }
 
+void GCodeProcessor::parse_warpage_fields(const std::string& comment)
+{
+    static const std::array<std::regex, 9> matchers = {
+        std::regex(R"((?:^|,)wdm=([+-]?(?:[0-9]+(?:\.[0-9]*)?|\.[0-9]+)(?:[eE][+-]?[0-9]+)?)(?=,|$))"),
+        std::regex(R"((?:^|,)wdx=([+-]?(?:[0-9]+(?:\.[0-9]*)?|\.[0-9]+)(?:[eE][+-]?[0-9]+)?)(?=,|$))"),
+        std::regex(R"((?:^|,)wdy=([+-]?(?:[0-9]+(?:\.[0-9]*)?|\.[0-9]+)(?:[eE][+-]?[0-9]+)?)(?=,|$))"),
+        std::regex(R"((?:^|,)wdz=([+-]?(?:[0-9]+(?:\.[0-9]*)?|\.[0-9]+)(?:[eE][+-]?[0-9]+)?)(?=,|$))"),
+        std::regex(R"((?:^|,)wr=([+-]?(?:[0-9]+(?:\.[0-9]*)?|\.[0-9]+)(?:[eE][+-]?[0-9]+)?)(?=,|$))"),
+        std::regex(R"((?:^|,)wtg=([+-]?(?:[0-9]+(?:\.[0-9]*)?|\.[0-9]+)(?:[eE][+-]?[0-9]+)?)(?=,|$))"),
+        std::regex(R"((?:^|,)wts=([+-]?(?:[0-9]+(?:\.[0-9]*)?|\.[0-9]+)(?:[eE][+-]?[0-9]+)?)(?=,|$))"),
+        std::regex(R"((?:^|,)whs=([+-]?(?:[0-9]+(?:\.[0-9]*)?|\.[0-9]+)(?:[eE][+-]?[0-9]+)?)(?=,|$))"),
+        std::regex(R"((?:^|,)wls=([+-]?(?:[0-9]+(?:\.[0-9]*)?|\.[0-9]+)(?:[eE][+-]?[0-9]+)?)(?=,|$))")
+    };
+
+    std::smatch match;
+    for (size_t i = 0; i < matchers.size(); ++i) {
+        if (std::regex_search(comment, match, matchers[i]))
+            m_warpage_fields[i] = static_cast<float>(std::atof(match[1].str().c_str()));
+    }
+}
+
 void GCodeProcessor::process_G0(const GCodeReader::GCodeLine& line)
 {
     process_G1(line);
@@ -3839,6 +3861,7 @@ void GCodeProcessor::process_G1(const GCodeReader::GCodeLine& line, const std::o
     m_thermal_index_mean = -200.0f;
     m_thermal_index_min = -200.0f;
     m_thermal_index_max = -200.0f;
+    m_warpage_fields.fill(NAN);
     {
         const std::string& raw = line.raw();
         auto pos = raw.find(";helioadditive=");
@@ -3852,6 +3875,7 @@ void GCodeProcessor::process_G1(const GCodeReader::GCodeLine& line, const std::o
                 m_thermal_index_mean = static_cast<float>(std::atof(match[3].str().c_str())) * 100.0f;
                 m_is_helio_gcode = true;
             }
+            parse_warpage_fields(comment_str);
         }
     }
 
@@ -4595,6 +4619,7 @@ void GCodeProcessor::process_G2_G3(const GCodeReader::GCodeLine& line, bool cloc
     m_thermal_index_mean = -200.0f;
     m_thermal_index_min = -200.0f;
     m_thermal_index_max = -200.0f;
+    m_warpage_fields.fill(NAN);
     {
         const std::string& raw = line.raw();
         auto pos = raw.find(";helioadditive=");
@@ -4608,6 +4633,7 @@ void GCodeProcessor::process_G2_G3(const GCodeReader::GCodeLine& line, bool cloc
                 m_thermal_index_mean = static_cast<float>(std::atof(match[3].str().c_str())) * 100.0f;
                 m_is_helio_gcode = true;
             }
+            parse_warpage_fields(comment_str);
         }
     }
 
@@ -5761,6 +5787,15 @@ void GCodeProcessor::store_move_vertex(EMoveType type, EMovePathType path_type, 
         m_thermal_index_mean,
         m_thermal_index_min,
         m_thermal_index_max,
+        m_warpage_fields[0],
+        m_warpage_fields[1],
+        m_warpage_fields[2],
+        m_warpage_fields[3],
+        m_warpage_fields[4],
+        m_warpage_fields[5],
+        m_warpage_fields[6],
+        m_warpage_fields[7],
+        m_warpage_fields[8],
         { 0.0f, 0.0f }, // time
         static_cast<float>(m_layer_id), //layer_duration: set later
         std::max<unsigned int>(1, m_layer_id) - 1,

--- a/src/libslic3r/GCode/GCodeProcessor.hpp
+++ b/src/libslic3r/GCode/GCodeProcessor.hpp
@@ -14,6 +14,7 @@
 #include <string>
 #include <string_view>
 #include <optional>
+#include <cmath>
 
 namespace Slic3r {
 
@@ -212,6 +213,15 @@ class Print;
             float thermal_index_mean{ -200.0f };
             float thermal_index_min{ -200.0f };
             float thermal_index_max{ -200.0f };
+            float warpage_displacement{ NAN };
+            float warpage_disp_x{ NAN };
+            float warpage_disp_y{ NAN };
+            float warpage_disp_z{ NAN };
+            float warpage_risk{ NAN };
+            float warpage_ti_gradient{ NAN };
+            float warpage_thermal_strain{ NAN };
+            float warpage_hull_shrinkage{ NAN };
+            float warpage_layer_shrinkage{ NAN };
             std::array<float, static_cast<size_t>(PrintEstimatedStatistics::ETimeMode::Count)> time{ 0.0f, 0.0f }; // s
             float layer_duration{ 0.0f }; // s
             unsigned int layer_id{ 0 };
@@ -835,6 +845,7 @@ class Print;
         float m_thermal_index_mean{ -200.0f };
         float m_thermal_index_min{ -200.0f };
         float m_thermal_index_max{ -200.0f };
+        std::array<float, 9> m_warpage_fields{ NAN, NAN, NAN, NAN, NAN, NAN, NAN, NAN, NAN };
         bool m_is_helio_gcode{false};
         ExtrusionRole m_extrusion_role;
         std::vector<int> m_filament_maps;
@@ -967,6 +978,7 @@ class Print;
         // Move
         void process_G0(const GCodeReader::GCodeLine& line);
         void process_G1(const GCodeReader::GCodeLine& line, const std::optional<unsigned int>& remaining_internal_g1_lines = std::nullopt);
+        void parse_warpage_fields(const std::string& comment);
         enum class G1DiscretizationOrigin {
             G1,
             G2G3,
@@ -1170,5 +1182,3 @@ class Print;
 } /* namespace Slic3r */
 
 #endif /* slic3r_GCodeProcessor_hpp_ */
-
-

--- a/src/libvgcode/include/PathVertex.hpp
+++ b/src/libvgcode/include/PathVertex.hpp
@@ -8,6 +8,7 @@
 #include "Types.hpp"
 
 #include <cfloat>
+#include <cmath>
 
 namespace libvgcode {
 
@@ -106,6 +107,15 @@ struct PathVertex
     float thermal_index_mean{ -200.0f };
     float thermal_index_min{ -200.0f };
     float thermal_index_max{ -200.0f };
+    float warpage_displacement{ NAN };
+    float warpage_disp_x{ NAN };
+    float warpage_disp_y{ NAN };
+    float warpage_disp_z{ NAN };
+    float warpage_risk{ NAN };
+    float warpage_ti_gradient{ NAN };
+    float warpage_thermal_strain{ NAN };
+    float warpage_hull_shrinkage{ NAN };
+    float warpage_layer_shrinkage{ NAN };
 
     //
     // Return true if the segment is an extrusion move

--- a/src/libvgcode/include/Types.hpp
+++ b/src/libvgcode/include/Types.hpp
@@ -102,6 +102,15 @@ enum class EViewType : uint8_t
     ThermalIndexMean,
     ThermalIndexMin,
     ThermalIndexMax,
+    WarpageDisplacement,
+    WarpageDispX,
+    WarpageDispY,
+    WarpageDispZ,
+    WarpageRisk,
+    WarpageTIGradient,
+    WarpageThermalStrain,
+    WarpageHullShrinkage,
+    WarpageLayerShrinkage,
     Tool,
     COUNT
 };

--- a/src/libvgcode/src/ViewerImpl.cpp
+++ b/src/libvgcode/src/ViewerImpl.cpp
@@ -1536,6 +1536,15 @@ Color ViewerImpl::get_vertex_color(const PathVertex& v) const
         if (v.thermal_index_max < -100.0f) return DUMMY_COLOR;
         return m_thermal_index_max_range.get_color_at(v.thermal_index_max);
     }
+    case EViewType::WarpageDisplacement: return std::isnan(v.warpage_displacement) ? DUMMY_COLOR : m_warpage_ranges[0].get_color_at(v.warpage_displacement);
+    case EViewType::WarpageDispX: return std::isnan(v.warpage_disp_x) ? DUMMY_COLOR : m_warpage_ranges[1].get_color_at(v.warpage_disp_x);
+    case EViewType::WarpageDispY: return std::isnan(v.warpage_disp_y) ? DUMMY_COLOR : m_warpage_ranges[2].get_color_at(v.warpage_disp_y);
+    case EViewType::WarpageDispZ: return std::isnan(v.warpage_disp_z) ? DUMMY_COLOR : m_warpage_ranges[3].get_color_at(v.warpage_disp_z);
+    case EViewType::WarpageRisk: return std::isnan(v.warpage_risk) ? DUMMY_COLOR : m_warpage_ranges[4].get_color_at(v.warpage_risk);
+    case EViewType::WarpageTIGradient: return std::isnan(v.warpage_ti_gradient) ? DUMMY_COLOR : m_warpage_ranges[5].get_color_at(v.warpage_ti_gradient);
+    case EViewType::WarpageThermalStrain: return std::isnan(v.warpage_thermal_strain) ? DUMMY_COLOR : m_warpage_ranges[6].get_color_at(v.warpage_thermal_strain);
+    case EViewType::WarpageHullShrinkage: return std::isnan(v.warpage_hull_shrinkage) ? DUMMY_COLOR : m_warpage_ranges[7].get_color_at(v.warpage_hull_shrinkage);
+    case EViewType::WarpageLayerShrinkage: return std::isnan(v.warpage_layer_shrinkage) ? DUMMY_COLOR : m_warpage_ranges[8].get_color_at(v.warpage_layer_shrinkage);
     case EViewType::VolumetricFlowRate:
     {
         return v.is_travel() ? get_option_color(move_type_to_option(v.type)) : m_volumetric_rate_range.get_color_at(v.volumetric_rate());
@@ -1634,6 +1643,15 @@ const ColorRange& ViewerImpl::get_color_range(EViewType type) const
     case EViewType::ThermalIndexMean:         { return m_thermal_index_mean_range; }
     case EViewType::ThermalIndexMin:          { return m_thermal_index_min_range; }
     case EViewType::ThermalIndexMax:          { return m_thermal_index_max_range; }
+    case EViewType::WarpageDisplacement: return m_warpage_ranges[0];
+    case EViewType::WarpageDispX: return m_warpage_ranges[1];
+    case EViewType::WarpageDispY: return m_warpage_ranges[2];
+    case EViewType::WarpageDispZ: return m_warpage_ranges[3];
+    case EViewType::WarpageRisk: return m_warpage_ranges[4];
+    case EViewType::WarpageTIGradient: return m_warpage_ranges[5];
+    case EViewType::WarpageThermalStrain: return m_warpage_ranges[6];
+    case EViewType::WarpageHullShrinkage: return m_warpage_ranges[7];
+    case EViewType::WarpageLayerShrinkage: return m_warpage_ranges[8];
     case EViewType::VolumetricFlowRate:       { return m_volumetric_rate_range; }
     case EViewType::ActualVolumetricFlowRate: { return m_actual_volumetric_rate_range; }
     case EViewType::LayerTimeLinear:          { return m_layer_time_range[0]; }
@@ -1661,6 +1679,15 @@ void ViewerImpl::set_color_range_palette(EViewType type, const Palette& palette)
     case EViewType::ThermalIndexMean:         { m_thermal_index_mean_range.set_palette(palette); break; }
     case EViewType::ThermalIndexMin:          { m_thermal_index_min_range.set_palette(palette); break; }
     case EViewType::ThermalIndexMax:          { m_thermal_index_max_range.set_palette(palette); break; }
+    case EViewType::WarpageDisplacement: m_warpage_ranges[0].set_palette(palette); break;
+    case EViewType::WarpageDispX: m_warpage_ranges[1].set_palette(palette); break;
+    case EViewType::WarpageDispY: m_warpage_ranges[2].set_palette(palette); break;
+    case EViewType::WarpageDispZ: m_warpage_ranges[3].set_palette(palette); break;
+    case EViewType::WarpageRisk: m_warpage_ranges[4].set_palette(palette); break;
+    case EViewType::WarpageTIGradient: m_warpage_ranges[5].set_palette(palette); break;
+    case EViewType::WarpageThermalStrain: m_warpage_ranges[6].set_palette(palette); break;
+    case EViewType::WarpageHullShrinkage: m_warpage_ranges[7].set_palette(palette); break;
+    case EViewType::WarpageLayerShrinkage: m_warpage_ranges[8].set_palette(palette); break;
     case EViewType::VolumetricFlowRate:       { m_volumetric_rate_range.set_palette(palette); break; }
     case EViewType::ActualVolumetricFlowRate: { m_actual_volumetric_rate_range.set_palette(palette); break; }
     case EViewType::LayerTimeLinear:          { m_layer_time_range[0].set_palette(palette);   break; }
@@ -1707,6 +1734,8 @@ size_t ViewerImpl::get_used_cpu_memory() const
     ret += m_thermal_index_mean_range.size_in_bytes_cpu();
     ret += m_thermal_index_min_range.size_in_bytes_cpu();
     ret += m_thermal_index_max_range.size_in_bytes_cpu();
+    for (const ColorRange& range : m_warpage_ranges)
+        ret += range.size_in_bytes_cpu();
     ret += m_volumetric_rate_range.size_in_bytes_cpu();
     ret += m_actual_volumetric_rate_range.size_in_bytes_cpu();
     for (size_t i = 0; i < COLOR_RANGE_TYPES_COUNT; ++i) {
@@ -1866,6 +1895,8 @@ void ViewerImpl::update_color_ranges()
     m_thermal_index_mean_range.reset();
     m_thermal_index_min_range.reset();
     m_thermal_index_max_range.reset();
+    for (ColorRange& range : m_warpage_ranges)
+        range.reset();
     // Helio: Use custom TI palette (blue→green→red) matching BambuStudio
     static const Palette TI_PALETTE{ {
         {  11,  44, 122 },  // #0b2c7a  -100 (blue)
@@ -1883,6 +1914,17 @@ void ViewerImpl::update_color_ranges()
     m_thermal_index_mean_range.set_palette(TI_PALETTE);
     m_thermal_index_min_range.set_palette(TI_PALETTE);
     m_thermal_index_max_range.set_palette(TI_PALETTE);
+    static const Palette WARPAGE_SEQUENTIAL{ {
+        { 30, 180, 60 }, { 140, 190, 40 }, { 220, 180, 30 }, { 230, 100, 20 }, { 200, 20, 20 }
+    } };
+    static const Palette WARPAGE_DIVERGING{ { { 0, 60, 200 }, { 30, 180, 60 }, { 200, 20, 20 } } };
+    static const Palette WARPAGE_DARK{ { { 25, 30, 50 }, { 30, 160, 60 }, { 220, 180, 30 }, { 200, 20, 20 } } };
+    for (ColorRange& range : m_warpage_ranges)
+        range.set_palette(WARPAGE_SEQUENTIAL);
+    m_warpage_ranges[1].set_palette(WARPAGE_DIVERGING);
+    m_warpage_ranges[2].set_palette(WARPAGE_DIVERGING);
+    m_warpage_ranges[3].set_palette(WARPAGE_DIVERGING);
+    m_warpage_ranges[7].set_palette(WARPAGE_DARK);
     // Anchor to fixed [-100, +100] so colors always match the legend
     m_thermal_index_mean_range.update(-100.0f);
     m_thermal_index_mean_range.update(100.0f);
@@ -1916,6 +1958,12 @@ void ViewerImpl::update_color_ranges()
                 m_thermal_index_min_range.update(v.thermal_index_min);
             if (v.thermal_index_max > -100.0f)
                 m_thermal_index_max_range.update(v.thermal_index_max);
+            const std::array<float, 9> warpage_values = { v.warpage_displacement, v.warpage_disp_x, v.warpage_disp_y,
+                v.warpage_disp_z, v.warpage_risk, v.warpage_ti_gradient, v.warpage_thermal_strain,
+                v.warpage_hull_shrinkage, v.warpage_layer_shrinkage };
+            for (size_t j = 0; j < warpage_values.size(); ++j)
+                if (!std::isnan(warpage_values[j]))
+                    m_warpage_ranges[j].update(warpage_values[j]);
         }
         if ((v.is_travel() && m_settings.options_visibility[size_t(EOptionType::Travels)]) ||
             (v.is_wipe() && m_settings.options_visibility[size_t(EOptionType::Wipes)]) ||

--- a/src/libvgcode/src/ViewerImpl.hpp
+++ b/src/libvgcode/src/ViewerImpl.hpp
@@ -299,6 +299,7 @@ private:
     ColorRange m_thermal_index_mean_range;
     ColorRange m_thermal_index_min_range;
     ColorRange m_thermal_index_max_range;
+    std::array<ColorRange, 9> m_warpage_ranges;
     ColorRange m_volumetric_rate_range;
     ColorRange m_actual_volumetric_rate_range;
     std::array<ColorRange, COLOR_RANGE_TYPES_COUNT> m_layer_time_range{

--- a/src/slic3r/GUI/GCodeViewer.cpp
+++ b/src/slic3r/GUI/GCodeViewer.cpp
@@ -63,6 +63,19 @@ namespace GUI {
 //        _u8L("Filament")
 //    };
 
+static bool is_thermal_view(libvgcode::EViewType view_type)
+{
+    return view_type == libvgcode::EViewType::ThermalIndexMean ||
+           view_type == libvgcode::EViewType::ThermalIndexMin ||
+           view_type == libvgcode::EViewType::ThermalIndexMax;
+}
+
+static bool is_warpage_view(libvgcode::EViewType view_type)
+{
+    return view_type >= libvgcode::EViewType::WarpageDisplacement &&
+           view_type <= libvgcode::EViewType::WarpageLayerShrinkage;
+}
+
 static std::string get_view_type_string(libvgcode::EViewType view_type)
 {
     if (view_type == libvgcode::EViewType::Summary)
@@ -107,6 +120,15 @@ static std::string get_view_type_string(libvgcode::EViewType view_type)
         return _u8L("Thermal Index (min)");
     else if (view_type == libvgcode::EViewType::ThermalIndexMax)
         return _u8L("Thermal Index (max)");
+    else if (view_type == libvgcode::EViewType::WarpageDisplacement) return _u8L("Warpage displacement");
+    else if (view_type == libvgcode::EViewType::WarpageDispX) return _u8L("Warpage displacement X");
+    else if (view_type == libvgcode::EViewType::WarpageDispY) return _u8L("Warpage displacement Y");
+    else if (view_type == libvgcode::EViewType::WarpageDispZ) return _u8L("Warpage displacement Z");
+    else if (view_type == libvgcode::EViewType::WarpageRisk) return _u8L("Warpage risk");
+    else if (view_type == libvgcode::EViewType::WarpageTIGradient) return _u8L("Warpage TI gradient");
+    else if (view_type == libvgcode::EViewType::WarpageThermalStrain) return _u8L("Warpage thermal strain");
+    else if (view_type == libvgcode::EViewType::WarpageHullShrinkage) return _u8L("Warpage hull shrinkage");
+    else if (view_type == libvgcode::EViewType::WarpageLayerShrinkage) return _u8L("Warpage layer shrinkage");
     return "";
 }
 
@@ -1195,6 +1217,17 @@ void GCodeViewer::update_by_mode(ConfigOptionMode mode)
         view_type_items.push_back(libvgcode::EViewType::ThermalIndexMin);
         view_type_items.push_back(libvgcode::EViewType::ThermalIndexMax);
     }
+    if (m_has_warpage_data) {
+        view_type_items.push_back(libvgcode::EViewType::WarpageDisplacement);
+        view_type_items.push_back(libvgcode::EViewType::WarpageDispX);
+        view_type_items.push_back(libvgcode::EViewType::WarpageDispY);
+        view_type_items.push_back(libvgcode::EViewType::WarpageDispZ);
+        view_type_items.push_back(libvgcode::EViewType::WarpageRisk);
+        view_type_items.push_back(libvgcode::EViewType::WarpageTIGradient);
+        view_type_items.push_back(libvgcode::EViewType::WarpageThermalStrain);
+        view_type_items.push_back(libvgcode::EViewType::WarpageHullShrinkage);
+        view_type_items.push_back(libvgcode::EViewType::WarpageLayerShrinkage);
+    }
     //if (mode == ConfigOptionMode::comDevelop) {
     //    view_type_items.push_back(EViewType::Tool);
     //}
@@ -1375,15 +1408,17 @@ void GCodeViewer::load_as_gcode(const GCodeProcessorResult& gcode_result, const 
     m_viewer.reset_default_extrusion_roles_colors();
     m_viewer.load(std::move(data));
 
-    // Helio: detect whether this gcode has any thermal index data
+    // Helio: expose simulation-only views only when their data is present.
     m_has_thermal_index_data = false;
+    m_has_warpage_data = false;
     {
         const size_t vcount = m_viewer.get_vertices_count();
         for (size_t i = 0; i < vcount; ++i) {
-            if (m_viewer.get_vertex_at(i).thermal_index_mean > -100.0f) {
-                m_has_thermal_index_data = true;
+            const libvgcode::PathVertex& vertex = m_viewer.get_vertex_at(i);
+            m_has_thermal_index_data |= vertex.thermal_index_mean > -100.0f;
+            m_has_warpage_data |= !std::isnan(vertex.warpage_displacement);
+            if (m_has_thermal_index_data && m_has_warpage_data)
                 break;
-            }
         }
     }
     update_by_mode(wxGetApp().get_mode());
@@ -1462,17 +1497,17 @@ void GCodeViewer::load_as_gcode(const GCodeProcessorResult& gcode_result, const 
     // load_toolpaths(gcode_result, build_volume, exclude_bounding_box);
     
     // ORCA: Apply smart default view type when extruder count changes.
-    // Helio: preserve ThermalIndex view type across plate switches / gcode reloads
+    // Helio: preserve simulation views across reloads only while their data exists.
     const auto cur_vt = get_view_type();
-    bool is_thermal_view = (cur_vt == libvgcode::EViewType::ThermalIndexMean ||
-                            cur_vt == libvgcode::EViewType::ThermalIndexMin ||
-                            cur_vt == libvgcode::EViewType::ThermalIndexMax);
-    if (is_thermal_view && m_has_thermal_index_data) {
+    const bool is_available_simulation_view =
+        (is_thermal_view(cur_vt) && m_has_thermal_index_data) ||
+        (is_warpage_view(cur_vt) && m_has_warpage_data);
+    if (is_available_simulation_view) {
         auto it = std::find(view_type_items.begin(), view_type_items.end(), cur_vt);
         if (it != view_type_items.end())
             m_view_type_sel = std::distance(view_type_items.begin(), it);
         set_view_type(cur_vt);
-    } else if (is_thermal_view) {
+    } else if (is_thermal_view(cur_vt) || is_warpage_view(cur_vt)) {
         auto it = std::find(view_type_items.begin(), view_type_items.end(), libvgcode::EViewType::FeatureType);
         if (it != view_type_items.end())
             m_view_type_sel = std::distance(view_type_items.begin(), it);
@@ -1595,21 +1630,21 @@ void GCodeViewer::load_as_gcode(const GCodeProcessorResult& gcode_result, const 
             m_viewer.set_time_mode(libvgcode::convert(PrintEstimatedStatistics::ETimeMode::Normal));
     }
 
-    // Helio: preserve ThermalIndex view type if the loaded data contains TI.
+    // Helio: keep simulation views only if the loaded data contains their metrics.
     // NOTE: the multi-extruder ColorPrint defaulting deliberately lives ONLY in
     // the block near the top of this function, which is gated by
     // m_last_extruder_count_default_applied so it applies once per extruder-count
     // change and then respects the user's manual view choice. Do not re-assert
     // ColorPrint here — an unconditional override would fire on every reload/plate
-    // switch and defeat that sentinel. This block only handles the TI case.
+    // switch and defeat that sentinel. This block only handles simulation views.
     {
         const auto cur_vt2 = get_view_type();
-        bool is_thermal2 = (cur_vt2 == libvgcode::EViewType::ThermalIndexMean ||
-                            cur_vt2 == libvgcode::EViewType::ThermalIndexMin ||
-                            cur_vt2 == libvgcode::EViewType::ThermalIndexMax);
-        if (is_thermal2 && m_has_thermal_index_data) {
-            // TI view with data — keep it
-        } else if (is_thermal2) {
+        const bool is_available_simulation_view =
+            (is_thermal_view(cur_vt2) && m_has_thermal_index_data) ||
+            (is_warpage_view(cur_vt2) && m_has_warpage_data);
+        if (is_available_simulation_view) {
+            // Simulation view with data — keep it.
+        } else if (is_thermal_view(cur_vt2) || is_warpage_view(cur_vt2)) {
             for (int i = 0; i < view_type_items.size(); i++) {
                 if (view_type_items[i] == libvgcode::EViewType::FeatureType) {
                     m_view_type_sel = i;
@@ -1678,15 +1713,17 @@ void GCodeViewer::load_as_preview(libvgcode::GCodeInputData&& data)
     m_viewer.set_extrusion_role_color(libvgcode::EGCodeExtrusionRole::WipeTower,                { 127, 255, 127 });
     m_viewer.load(std::move(data));
 
-    // Helio: detect whether this gcode has any thermal index data
+    // Helio: expose simulation-only views only when their data is present.
     m_has_thermal_index_data = false;
+    m_has_warpage_data = false;
     {
         const size_t vcount = m_viewer.get_vertices_count();
         for (size_t i = 0; i < vcount; ++i) {
-            if (m_viewer.get_vertex_at(i).thermal_index_mean > -100.0f) {
-                m_has_thermal_index_data = true;
+            const libvgcode::PathVertex& vertex = m_viewer.get_vertex_at(i);
+            m_has_thermal_index_data |= vertex.thermal_index_mean > -100.0f;
+            m_has_warpage_data |= !std::isnan(vertex.warpage_displacement);
+            if (m_has_thermal_index_data && m_has_warpage_data)
                 break;
-            }
         }
     }
     update_by_mode(wxGetApp().get_mode());
@@ -3892,6 +3929,15 @@ void GCodeViewer::render_legend(float &legend_height, int canvas_width, int canv
         { imgui.title(_u8L("Thermal Index (min)")); break; }
     case libvgcode::EViewType::ThermalIndexMax:
         { imgui.title(_u8L("Thermal Index (max)")); break; }
+    case libvgcode::EViewType::WarpageDisplacement: { imgui.title(_u8L("Warpage displacement (mm)")); break; }
+    case libvgcode::EViewType::WarpageDispX: { imgui.title(_u8L("Warpage displacement X (mm)")); break; }
+    case libvgcode::EViewType::WarpageDispY: { imgui.title(_u8L("Warpage displacement Y (mm)")); break; }
+    case libvgcode::EViewType::WarpageDispZ: { imgui.title(_u8L("Warpage displacement Z (mm)")); break; }
+    case libvgcode::EViewType::WarpageRisk: { imgui.title(_u8L("Warpage risk")); break; }
+    case libvgcode::EViewType::WarpageTIGradient: { imgui.title(_u8L("Warpage TI gradient")); break; }
+    case libvgcode::EViewType::WarpageThermalStrain: { imgui.title(_u8L("Warpage thermal strain")); break; }
+    case libvgcode::EViewType::WarpageHullShrinkage: { imgui.title(_u8L("Warpage hull shrinkage")); break; }
+    case libvgcode::EViewType::WarpageLayerShrinkage: { imgui.title(_u8L("Warpage layer shrinkage")); break; }
 
     case libvgcode::EViewType::Tool:
     {
@@ -4221,6 +4267,17 @@ void GCodeViewer::render_legend(float &legend_height, int canvas_width, int canv
 
         break;
     }
+    case libvgcode::EViewType::WarpageDisplacement:
+    case libvgcode::EViewType::WarpageDispX:
+    case libvgcode::EViewType::WarpageDispY:
+    case libvgcode::EViewType::WarpageDispZ:
+    case libvgcode::EViewType::WarpageRisk:
+    case libvgcode::EViewType::WarpageTIGradient:
+    case libvgcode::EViewType::WarpageThermalStrain:
+    case libvgcode::EViewType::WarpageHullShrinkage:
+    case libvgcode::EViewType::WarpageLayerShrinkage:
+        append_range(m_viewer.get_color_range(curr_view_type), 4);
+        break;
     case libvgcode::EViewType::Tool:
     {
         // shows only extruders actually used
@@ -4953,4 +5010,3 @@ void GCodeViewer::render_slider(int canvas_width, int canvas_height) {
 
 } // namespace GUI
 } // namespace Slic3r
-

--- a/src/slic3r/GUI/GCodeViewer.hpp
+++ b/src/slic3r/GUI/GCodeViewer.hpp
@@ -253,6 +253,7 @@ mutable bool m_no_render_path { false };
     libvgcode::Viewer m_viewer;
     bool m_loaded_as_preview{ false };
     bool m_has_thermal_index_data{ false };
+    bool m_has_warpage_data{ false };
 
 public:
     GCodeViewer();
@@ -384,4 +385,3 @@ private:
 } // namespace Slic3r
 
 #endif // slic3r_GCodeViewer_hpp_
-

--- a/src/slic3r/GUI/LibVGCode/LibVGCodeWrapper.cpp
+++ b/src/slic3r/GUI/LibVGCode/LibVGCodeWrapper.cpp
@@ -228,7 +228,9 @@ GCodeInputData convert(const Slic3r::GCodeProcessorResult& result, const std::ve
                     /* ORCA: Add Pressure Advance visualization support */ 0.0f, curr.pressure_advance,
                     /* ORCA: Add Acceleration visualization support */ curr.acceleration,
                     /* ORCA: Add Jerk visualization support */ curr.jerk,
-            /* Helio: Thermal index from simulation */ curr.thermal_index_mean, curr.thermal_index_min, curr.thermal_index_max };
+            /* Helio: Thermal index from simulation */ curr.thermal_index_mean, curr.thermal_index_min, curr.thermal_index_max,
+            curr.warpage_displacement, curr.warpage_disp_x, curr.warpage_disp_y, curr.warpage_disp_z, curr.warpage_risk,
+            curr.warpage_ti_gradient, curr.warpage_thermal_strain, curr.warpage_hull_shrinkage, curr.warpage_layer_shrinkage };
 #else
               const libvgcode::PathVertex vertex = { convert(prev.position), curr.height, curr.width, curr.feedrate, prev.actual_feedrate,
                     curr.mm3_per_mm, curr.fan_speed, curr.temperature, convert(curr.extrusion_role), curr_type,
@@ -237,7 +239,9 @@ GCodeInputData convert(const Slic3r::GCodeProcessorResult& result, const std::ve
                     /* ORCA: Add Pressure Advance visualization support */ 0.0f, curr.pressure_advance,
                     /* ORCA: Add Acceleration visualization support */ curr.acceleration,
                     /* ORCA: Add Jerk visualization support */ curr.jerk,
-            /* Helio: Thermal index from simulation */ curr.thermal_index_mean, curr.thermal_index_min, curr.thermal_index_max };
+            /* Helio: Thermal index from simulation */ curr.thermal_index_mean, curr.thermal_index_min, curr.thermal_index_max,
+            curr.warpage_displacement, curr.warpage_disp_x, curr.warpage_disp_y, curr.warpage_disp_z, curr.warpage_risk,
+            curr.warpage_ti_gradient, curr.warpage_thermal_strain, curr.warpage_hull_shrinkage, curr.warpage_layer_shrinkage };
 #endif // VGCODE_ENABLE_COG_AND_TOOL_MARKERS
                 ret.vertices.emplace_back(vertex);
             }
@@ -252,7 +256,9 @@ GCodeInputData convert(const Slic3r::GCodeProcessorResult& result, const std::ve
             /* ORCA: Add Pressure Advance visualization support */ 0.0f, curr.pressure_advance,
             /* ORCA: Add Acceleration visualization support */ curr.acceleration,
             /* ORCA: Add Jerk visualization support */ curr.jerk,
-            /* Helio: Thermal index from simulation */ curr.thermal_index_mean, curr.thermal_index_min, curr.thermal_index_max };
+            /* Helio: Thermal index from simulation */ curr.thermal_index_mean, curr.thermal_index_min, curr.thermal_index_max,
+            curr.warpage_displacement, curr.warpage_disp_x, curr.warpage_disp_y, curr.warpage_disp_z, curr.warpage_risk,
+            curr.warpage_ti_gradient, curr.warpage_thermal_strain, curr.warpage_hull_shrinkage, curr.warpage_layer_shrinkage };
 #else
         const libvgcode::PathVertex vertex = { convert(curr.position), curr.height, curr.width, curr.feedrate, curr.actual_feedrate,
             curr.mm3_per_mm, curr.fan_speed, curr.temperature, convert(curr.extrusion_role), curr_type,
@@ -261,7 +267,9 @@ GCodeInputData convert(const Slic3r::GCodeProcessorResult& result, const std::ve
             /* ORCA: Add Pressure Advance visualization support */ 0.0f, curr.pressure_advance,
             /* ORCA: Add Acceleration visualization support */ curr.acceleration,
             /* ORCA: Add Jerk visualization support */ curr.jerk,
-            /* Helio: Thermal index from simulation */ curr.thermal_index_mean, curr.thermal_index_min, curr.thermal_index_max };
+            /* Helio: Thermal index from simulation */ curr.thermal_index_mean, curr.thermal_index_min, curr.thermal_index_max,
+            curr.warpage_displacement, curr.warpage_disp_x, curr.warpage_disp_y, curr.warpage_disp_z, curr.warpage_risk,
+            curr.warpage_ti_gradient, curr.warpage_thermal_strain, curr.warpage_hull_shrinkage, curr.warpage_layer_shrinkage };
 #endif // VGCODE_ENABLE_COG_AND_TOOL_MARKERS
         ret.vertices.emplace_back(vertex);
     }
@@ -834,4 +842,3 @@ GCodeInputData convert(const Slic3r::Print& print, const std::vector<std::string
 }
 
 } // namespace libvgcode
-


### PR DESCRIPTION
### Motivation
- Surface additional Helio simulation metrics (warpage-related fields) embedded in `;helioadditive=` comments so they can be inspected in the G-code viewer. 
- Extend the toolpath data model and viewer to carry and visualize multiple warpage metrics consistently with existing Thermal Index (TI) support. 
- Only expose the new warpage views when the loaded G-code actually contains warpage data to avoid cluttering the UI.

### Description
- Parse warpage fields from Helio comments by adding `GCodeProcessor::parse_warpage_fields()` with dedicated regexes for `wdm, wdx, wdy, wdz, wr, wtg, wts, whs, wls` and populate `m_warpage_fields`, resetting to `NAN` at move start. 
- Extend `MoveVertex` / `GCodeProcessorResult` and `libvgcode::PathVertex` with nine `warpage_*` floats and carry them through `store_move_vertex`, the LibVGCode wrapper, and the viewer data path. 
- Add new view types in `Types.hpp` for each warpage metric and add a `std::array<ColorRange,9> m_warpage_ranges` to `ViewerImpl` with palette defaults and range updates during `update_color_ranges()`. 
- Add viewer-side logic in `GCodeViewer` to detect `m_has_warpage_data`, expose warpage view items when present, preserve/restore simulation views only when data exists, and render legends/labels for the new views. 
- Wire coloring and memory accounting for the new ranges and update `get_vertex_color()` to map warpage view types to appropriate ranges. 
- Misc: added necessary `#include <cmath>` and small helper functions `is_thermal_view()` / `is_warpage_view()` in the GUI wrapper.

### Testing
- Performed a full project build with the modified components; the build completed successfully. 
- Ran the libvgcode viewer range/unit checks and the G-code viewer smoke load for a sample G-code containing `;helioadditive=` comments; thermal-index and warpage views are detected and rendered as expected. 
- No automated test failures observed during the build and viewer smoke tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8e40c94158832b97ccfcfed708d314)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added warpage simulation data support when processing G-code.
  * Added nine warpage visualization modes, including displacement, risk, thermal strain, and shrinkage.
  * Warpage metrics are displayed with dedicated color ranges and legends in the G-code viewer.
  * Warpage views are available when simulation data is present and reset automatically when unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->