### PR TITLE
Display Helio warpage fields with an experimental analysis toggle

### DIFF
--- a/HELIO_INTEGRATION.md
+++ b/HELIO_INTEGRATION.md
@@ -40,6 +40,8 @@ Key data flow:
 - `HelioPlateResult` — per-plate result storage on `PartPlate`
 - `HelioCompletionEvent` — carries result path + quality metrics to UI thread
 - Thermal Index — parsed from `;helioadditive=` gcode comments in `GCodeProcessor`
+- Warpage metrics — parsed from the same `;helioadditive=` comments (keys `wdm`, `wdx`,
+  `wdy`, `wdz`, `wr`, `wtg`, `wts`, `whs`, `wls`) and from `WARPAGE_*` header tags
 
 ## Helio-Only Files (36 files — NEVER exist upstream, always preserve)
 
@@ -195,7 +197,14 @@ The heaviest modification. Contains the entire Helio processing pipeline.
 
 #### `src/slic3r/GUI/LibVGCode/LibVGCodeWrapper.cpp` (+8/-8)
 - **4 positional initializer lists modified**: appended `curr.thermal_index_mean, curr.thermal_index_min, curr.thermal_index_max` to `PathVertex` aggregate initializations
+- Then appended the **9 `curr.warpage_*` floats** after those, so each of the 4 lists now
+  carries **12 trailing floats**
 - Very fragile — if upstream changes `PathVertex` fields or reorders initializer, these break
+- **The failure is silent, and 12 same-typed values make it likelier.** All 12 are `float`,
+  so dropping one, duplicating one, or getting the order wrong still *compiles*: the values
+  simply land in the wrong members and the viewer paints wrong colours. There is no
+  compiler error to catch it and no test that would. When resolving a conflict here, check
+  the order against `PathVertex.hpp` field-by-field rather than eyeballing the list length
 
 ### MEDIUM RISK
 
@@ -244,8 +253,11 @@ The heaviest modification. Contains the entire Helio processing pipeline.
 
 #### `src/libslic3r/GCode/GCodeProcessor.hpp` (+4)
 - Added to `GCodeProcessorResult`: `bool is_helio_gcode`
-- Added to `MoveVertex`: `thermal_index_mean/min/max` floats
-- Added member variables: `m_thermal_index_mean/min/max`, `m_is_helio_gcode`
+- Added to `MoveVertex`: `thermal_index_mean/min/max` floats, then the 9 `warpage_*` floats
+- Added member variables: `m_thermal_index_mean/min/max`, `m_is_helio_gcode`,
+  `std::array<float, 9> m_warpage_fields`
+- `MoveVertex`'s members feed the positional initializers in `LibVGCodeWrapper.cpp` and the
+  `store_move_vertex()` aggregate — **adding or reordering a field here means updating both**
 
 #### `src/libvgcode/src/ViewerImpl.cpp` (+33)
 - **3 switch statements**: Added `ThermalIndexMean/Min/Max` cases in `get_vertex_color()`, `get_range()`, `set_palette()`
@@ -253,6 +265,8 @@ The heaviest modification. Contains the entire Helio processing pipeline.
 
 #### `src/libvgcode/src/ViewerImpl.hpp` (+2)
 - 3 new members: `m_thermal_index_mean_range`, `m_thermal_index_min_range`, `m_thermal_index_max_range`
+- Plus `std::array<ColorRange, 9> m_warpage_ranges` — indexed positionally in the order the
+  `EViewType` warpage values are declared, so the enum order and the array index must agree
 
 #### `src/slic3r/GUI/Widgets/TextInput.hpp` (+63)
 - Added `#include <memory>`, `#include <vector>`, forward declaration
@@ -276,9 +290,25 @@ The heaviest modification. Contains the entire Helio processing pipeline.
 
 #### `src/libvgcode/include/PathVertex.hpp` (+4)
 - Appended 3 floats to `PathVertex` struct: `thermal_index_mean/min/max`
+- Then appended 9 more: `warpage_displacement`, `warpage_disp_x/y/z`, `warpage_risk`,
+  `warpage_ti_gradient`, `warpage_thermal_strain`, `warpage_hull_shrinkage`,
+  `warpage_layer_shrinkage` — **12 appended floats in total**. The TI three default to
+  `-200.0f` and use a `< -100.0f` sentinel; the warpage nine default to `NAN` and use
+  `std::isnan()`. Do not unify these — the TI sentinel is a real value in the palette range
 
 #### `src/libvgcode/include/Types.hpp` (+2)
 - Appended 3 enum values to `EViewType`: `ThermalIndexMean`, `ThermalIndexMin`, `ThermalIndexMax`
+- Then 9 more for warpage: `WarpageDisplacement`, `WarpageDispX/Y/Z`, `WarpageRisk`,
+  `WarpageTIGradient`, `WarpageThermalStrain`, `WarpageHullShrinkage`,
+  `WarpageLayerShrinkage` — **12 in total, all inserted before `Tool`**
+- `GCodeViewer.cpp`'s `is_warpage_view()` tests the range
+  `>= WarpageDisplacement && <= WarpageLayerShrinkage`, so **the nine must stay
+  contiguous and in order**. Splitting them, or letting an upstream view type land
+  between them, silently widens or breaks that test
+- Inserting before `Tool` shifts the numeric value of `Tool` and `COUNT`. That is safe
+  today because `EViewType` is never serialized — it appears nowhere in `src/libslic3r/`
+  and no `AppConfig` key stores it. If upstream ever starts persisting the view type,
+  this becomes a migration concern
 
 #### `src/slic3r/CMakeLists.txt` (+12)
 - Appended 12 source file entries (6 hpp + 6 cpp for Helio files), including
@@ -351,15 +381,29 @@ Files where Helio code is inserted within upstream functions: `Plater.cpp`, `Mai
 
 ### Rule 4: Switch Statement Cases
 Files: `GCodeViewer.cpp`, `ViewerImpl.cpp`.
-- Add `ThermalIndexMean/Min/Max` cases alongside upstream's existing cases
+- Add `ThermalIndexMean/Min/Max` and the 9 `Warpage*` cases alongside upstream's existing cases
 - If upstream reordered `EViewType` enum, match new order
-- If upstream added new view types, ensure TI cases don't conflict
+- If upstream added new view types, ensure TI and warpage cases don't conflict
+- Each simulation view type needs a case in **four** places, and a conflict resolution that
+  restores three of them leaves no compiler error: `get_vertex_color()`,
+  `get_color_range()`, `set_color_range_palette()` (all `ViewerImpl.cpp`) and the legend
+  title switch in `GCodeViewer.cpp::render_legend()`. Grep for one of the view-type names
+  and confirm you get all four before calling a resolution done
+- **Every range view returns the travel colour for travel moves** —
+  `if (v.is_travel()) return get_option_color(move_type_to_option(v.type));` comes *first*,
+  before the no-data sentinel test. Omitting it does not fail to compile; travels just
+  render `DUMMY_COLOR`, which is also what a data-less extrusion renders, so the two become
+  indistinguishable. This was a real defect in the warpage cases, fixed on #126
 
 ### Rule 5: Positional Initializer Lists
 File: `LibVGCodeWrapper.cpp`.
-- 4 `PathVertex` aggregate initializations have `thermal_index_mean/min/max` appended
+- 4 `PathVertex` aggregate initializations have `thermal_index_mean/min/max` plus the 9
+  `warpage_*` floats appended — **12 trailing floats each**
 - If upstream changes `PathVertex` struct layout, these MUST be reordered to match
 - If upstream switches from aggregate to designated initializers, convert accordingly
+- Because all 12 are the same type, a wrong order or a dropped value compiles cleanly and
+  corrupts the visualization silently. Verify against `PathVertex.hpp` field-by-field;
+  matching the *count* is not enough
 
 ### Rule 6: Modified Function Signatures
 Files: `NotificationManager.hpp/cpp`.

--- a/HELIO_INTEGRATION.md
+++ b/HELIO_INTEGRATION.md
@@ -221,6 +221,7 @@ The heaviest modification. Contains the entire Helio processing pipeline.
 #### `src/slic3r/GUI/Preferences.cpp` (+79)
 - Added `#include "../Utils/HelioDragon.hpp"`
 - **New "Helio" tab** appended to preferences: enable toggle, PAT input (password field), multi-material and warping-analysis toggles, API URL display
+- **Warping-analysis compatibility**: `enableWarpingAnalysis` is added to `simulationSettings` only when the experiment is enabled. Keep the field omitted on the default disabled path so clients remain compatible with regional GraphQL schemas that predate the experiment
 - **Toggle listener**: `enable_helio_processing` toggle immediately shows/hides the Helio button in MainFrame via `ShowExpandButton()` + `Layout()` (no restart required)
 - **Region combobox**: both region-write paths call `HelioQuery::invalidate_support_data_for_endpoint_change()` — region selects both the Helio endpoint and which regional PAT key is read, so the previous endpoint's catalogs must be dropped
 

--- a/HELIO_INTEGRATION.md
+++ b/HELIO_INTEGRATION.md
@@ -220,7 +220,7 @@ The heaviest modification. Contains the entire Helio processing pipeline.
 
 #### `src/slic3r/GUI/Preferences.cpp` (+79)
 - Added `#include "../Utils/HelioDragon.hpp"`
-- **New "Helio" tab** appended to preferences: enable toggle, PAT input (password field), multi-material toggle, API URL display
+- **New "Helio" tab** appended to preferences: enable toggle, PAT input (password field), multi-material and warping-analysis toggles, API URL display
 - **Toggle listener**: `enable_helio_processing` toggle immediately shows/hides the Helio button in MainFrame via `ShowExpandButton()` + `Layout()` (no restart required)
 - **Region combobox**: both region-write paths call `HelioQuery::invalidate_support_data_for_endpoint_change()` — region selects both the Helio endpoint and which regional PAT key is read, so the previous endpoint's catalogs must be dropped
 
@@ -280,7 +280,7 @@ The heaviest modification. Contains the entire Helio processing pipeline.
 ### LOW RISK
 
 #### `src/libslic3r/AppConfig.cpp` (+25)
-- **Appended** defaults block in `set_defaults()`: `helio_api_url`, `enable_helio_processing` (defaults to `false`), `helio_api_china`, `helio_api_other`, `helio_multimaterial_enabled`, `helio_first_time_tutorial`
+- **Appended** defaults block in `set_defaults()`: `helio_api_url`, `enable_helio_processing` (defaults to `false`), `helio_api_china`, `helio_api_other`, `helio_multimaterial_enabled`, `helio_warping_analysis_enabled`, `helio_first_time_tutorial`
 
 #### `src/libslic3r/PrintBase.hpp` (+1)
 - Added `bool is_helio { false }` to `SlicingStatus` struct

--- a/HELIO_INTEGRATION.md
+++ b/HELIO_INTEGRATION.md
@@ -221,7 +221,7 @@ The heaviest modification. Contains the entire Helio processing pipeline.
 #### `src/slic3r/GUI/Preferences.cpp` (+79)
 - Added `#include "../Utils/HelioDragon.hpp"`
 - **New "Helio" tab** appended to preferences: enable toggle, PAT input (password field), multi-material and warping-analysis toggles, API URL display
-- **Warping-analysis compatibility**: `enableWarpingAnalysis` is added to `simulationSettings` only when the experiment is enabled. Keep the field omitted on the default disabled path so clients remain compatible with regional GraphQL schemas that predate the experiment
+- **Warping-analysis compatibility**: `enableWarpingAnalysis` is added to `simulationSettings` only when the experiment is enabled. Keep the field omitted on the default disabled path so clients remain compatible with regional GraphQL schemas that predate the experiment. Each service endpoint must add the optional field to its `simulationSettings` input and start warping analysis when it is `true` before enabling the experiment for users on that endpoint; otherwise GraphQL validation will reject the create-simulation request. No service change is required for users who leave the experiment disabled
 - **Toggle listener**: `enable_helio_processing` toggle immediately shows/hides the Helio button in MainFrame via `ShowExpandButton()` + `Layout()` (no restart required)
 - **Region combobox**: both region-write paths call `HelioQuery::invalidate_support_data_for_endpoint_change()` — region selects both the Helio endpoint and which regional PAT key is read, so the previous endpoint's catalogs must be dropped
 

--- a/src/libslic3r/AppConfig.cpp
+++ b/src/libslic3r/AppConfig.cpp
@@ -530,6 +530,9 @@ void AppConfig::set_defaults()
     if (get("helio_multimaterial_enabled").empty()) {
         set("helio_multimaterial_enabled", "false");
     }
+    if (get("helio_warping_analysis_enabled").empty()) {
+        set("helio_warping_analysis_enabled", "false");
+    }
     if (get("helio_first_time_tutorial").empty()) {
         set("helio_first_time_tutorial", "active");
     }

--- a/src/libslic3r/GCode/GCodeProcessor.cpp
+++ b/src/libslic3r/GCode/GCodeProcessor.cpp
@@ -45,6 +45,30 @@ static const float DEFAULT_ACCELERATION = 1500.0f; // Prusa Firmware 1_75mm_MK2
 static const float DEFAULT_RETRACT_ACCELERATION = 1500.0f; // Prusa Firmware 1_75mm_MK2
 static const float DEFAULT_TRAVEL_ACCELERATION = 1250.0f;
 
+static void parse_warpage_fields(std::string_view fields, std::array<float, 9>& values)
+{
+    static constexpr std::array<std::string_view, 9> keys = { "wdm", "wdx", "wdy", "wdz", "wr", "wtg", "wts", "whs", "wls" };
+
+    while (!fields.empty()) {
+        const size_t           delimiter = fields.find(',');
+        const std::string_view field     = fields.substr(0, delimiter);
+        const size_t           separator = field.find('=');
+        if (separator != std::string_view::npos) {
+            const auto key = std::find(keys.begin(), keys.end(), field.substr(0, separator));
+            if (key != keys.end()) {
+                const std::string_view number = field.substr(separator + 1);
+                float                  value;
+                const auto [end, error] = fast_float::from_chars(number.data(), number.data() + number.size(), value);
+                if (error == std::errc() && end == number.data() + number.size())
+                    values[std::distance(keys.begin(), key)] = value;
+            }
+        }
+        if (delimiter == std::string_view::npos)
+            break;
+        fields.remove_prefix(delimiter + 1);
+    }
+}
+
 static const size_t MIN_EXTRUDERS_COUNT = 5;
 static const float DEFAULT_FILAMENT_DIAMETER = 1.75f;
 static const int   DEFAULT_FILAMENT_HRC = 0;
@@ -1686,9 +1710,6 @@ void GCodeProcessorResult::reset() {
     filament_change_count_map.clear();
     warnings.clear();
     is_helio_gcode = false;
-    warpage_shrinkage_x_pct = warpage_shrinkage_y_pct = warpage_shrinkage_z_pct = NAN;
-    warpage_max_displacement_mm = warpage_max_hull_shrinkage_um = NAN;
-    warpage_wdm_p95 = warpage_whs_p95 = NAN;
 
     //BBS: add mutex for protection of gcode result
     unlock();
@@ -3166,23 +3187,8 @@ void GCodeProcessor::process_tags(const std::string_view comment, bool producers
         return;
     }
 
-    // Helio thermal index: handled in process_G1() to ensure parsing occurs before vertex storage
-    const auto parse_warpage_header = [&comment](const std::string_view prefix, float& target) {
-        if (!boost::starts_with(comment, prefix))
-            return false;
-        try {
-            target = static_cast<float>(string_to_double_decimal_point(std::string(comment.substr(prefix.size()))));
-        } catch (...) {}
-        return true;
-    };
-    if (parse_warpage_header(" WARPAGE_SHRINKAGE_X_PCT=", m_result.warpage_shrinkage_x_pct) ||
-        parse_warpage_header(" WARPAGE_SHRINKAGE_Y_PCT=", m_result.warpage_shrinkage_y_pct) ||
-        parse_warpage_header(" WARPAGE_SHRINKAGE_Z_PCT=", m_result.warpage_shrinkage_z_pct) ||
-        parse_warpage_header(" WARPAGE_MAX_DISPLACEMENT_MM=", m_result.warpage_max_displacement_mm) ||
-        parse_warpage_header(" WARPAGE_MAX_HULL_SHRINKAGE_UM=", m_result.warpage_max_hull_shrinkage_um) ||
-        parse_warpage_header(" WARPAGE_WDM_P95=", m_result.warpage_wdm_p95) ||
-        parse_warpage_header(" WARPAGE_WHS_P95=", m_result.warpage_whs_p95))
-        return;
+    // Helio thermal index and warpage fields are handled while processing moves so
+    // they are available before the corresponding vertex is stored.
 
     // wipe start tag
     if (boost::starts_with(comment, reserved_tag(ETags::Wipe_Start))) {
@@ -3872,12 +3878,7 @@ void GCodeProcessor::process_G1(const GCodeReader::GCodeLine& line, const std::o
                 m_thermal_index_mean = static_cast<float>(std::atof(match[3].str().c_str())) * 100.0f;
                 m_is_helio_gcode = true;
             }
-            const std::array<const char*, 9> keys = { "wdm", "wdx", "wdy", "wdz", "wr", "wtg", "wts", "whs", "wls" };
-            for (size_t i = 0; i < keys.size(); ++i) {
-                const std::regex field_re(std::string("(?:^|,)") + keys[i] + "=(-?[0-9]*\\.?[0-9]+)");
-                if (std::regex_search(comment_str, match, field_re))
-                    m_warpage_fields[i] = static_cast<float>(std::atof(match[1].str().c_str()));
-            }
+            parse_warpage_fields(std::string_view(raw).substr(pos + sizeof(";helioadditive=") - 1), m_warpage_fields);
         }
     }
 
@@ -4635,12 +4636,7 @@ void GCodeProcessor::process_G2_G3(const GCodeReader::GCodeLine& line, bool cloc
                 m_thermal_index_mean = static_cast<float>(std::atof(match[3].str().c_str())) * 100.0f;
                 m_is_helio_gcode = true;
             }
-            const std::array<const char*, 9> keys = { "wdm", "wdx", "wdy", "wdz", "wr", "wtg", "wts", "whs", "wls" };
-            for (size_t i = 0; i < keys.size(); ++i) {
-                const std::regex field_re(std::string("(?:^|,)") + keys[i] + "=(-?[0-9]*\\.?[0-9]+)");
-                if (std::regex_search(comment_str, match, field_re))
-                    m_warpage_fields[i] = static_cast<float>(std::atof(match[1].str().c_str()));
-            }
+            parse_warpage_fields(std::string_view(raw).substr(pos + sizeof(";helioadditive=") - 1), m_warpage_fields);
         }
     }
 

--- a/src/libslic3r/GCode/GCodeProcessor.cpp
+++ b/src/libslic3r/GCode/GCodeProcessor.cpp
@@ -1686,6 +1686,9 @@ void GCodeProcessorResult::reset() {
     filament_change_count_map.clear();
     warnings.clear();
     is_helio_gcode = false;
+    warpage_shrinkage_x_pct = warpage_shrinkage_y_pct = warpage_shrinkage_z_pct = NAN;
+    warpage_max_displacement_mm = warpage_max_hull_shrinkage_um = NAN;
+    warpage_wdm_p95 = warpage_whs_p95 = NAN;
 
     //BBS: add mutex for protection of gcode result
     unlock();
@@ -3164,6 +3167,22 @@ void GCodeProcessor::process_tags(const std::string_view comment, bool producers
     }
 
     // Helio thermal index: handled in process_G1() to ensure parsing occurs before vertex storage
+    const auto parse_warpage_header = [&comment](const std::string_view prefix, float& target) {
+        if (!boost::starts_with(comment, prefix))
+            return false;
+        try {
+            target = static_cast<float>(string_to_double_decimal_point(std::string(comment.substr(prefix.size()))));
+        } catch (...) {}
+        return true;
+    };
+    if (parse_warpage_header(" WARPAGE_SHRINKAGE_X_PCT=", m_result.warpage_shrinkage_x_pct) ||
+        parse_warpage_header(" WARPAGE_SHRINKAGE_Y_PCT=", m_result.warpage_shrinkage_y_pct) ||
+        parse_warpage_header(" WARPAGE_SHRINKAGE_Z_PCT=", m_result.warpage_shrinkage_z_pct) ||
+        parse_warpage_header(" WARPAGE_MAX_DISPLACEMENT_MM=", m_result.warpage_max_displacement_mm) ||
+        parse_warpage_header(" WARPAGE_MAX_HULL_SHRINKAGE_UM=", m_result.warpage_max_hull_shrinkage_um) ||
+        parse_warpage_header(" WARPAGE_WDM_P95=", m_result.warpage_wdm_p95) ||
+        parse_warpage_header(" WARPAGE_WHS_P95=", m_result.warpage_whs_p95))
+        return;
 
     // wipe start tag
     if (boost::starts_with(comment, reserved_tag(ETags::Wipe_Start))) {
@@ -3839,6 +3858,7 @@ void GCodeProcessor::process_G1(const GCodeReader::GCodeLine& line, const std::o
     m_thermal_index_mean = -200.0f;
     m_thermal_index_min = -200.0f;
     m_thermal_index_max = -200.0f;
+    m_warpage_fields.fill(NAN);
     {
         const std::string& raw = line.raw();
         auto pos = raw.find(";helioadditive=");
@@ -3851,6 +3871,12 @@ void GCodeProcessor::process_G1(const GCodeReader::GCodeLine& line, const std::o
                 m_thermal_index_min = static_cast<float>(std::atof(match[2].str().c_str())) * 100.0f;
                 m_thermal_index_mean = static_cast<float>(std::atof(match[3].str().c_str())) * 100.0f;
                 m_is_helio_gcode = true;
+            }
+            const std::array<const char*, 9> keys = { "wdm", "wdx", "wdy", "wdz", "wr", "wtg", "wts", "whs", "wls" };
+            for (size_t i = 0; i < keys.size(); ++i) {
+                const std::regex field_re(std::string("(?:^|,)") + keys[i] + "=(-?[0-9]*\\.?[0-9]+)");
+                if (std::regex_search(comment_str, match, field_re))
+                    m_warpage_fields[i] = static_cast<float>(std::atof(match[1].str().c_str()));
             }
         }
     }
@@ -4595,6 +4621,7 @@ void GCodeProcessor::process_G2_G3(const GCodeReader::GCodeLine& line, bool cloc
     m_thermal_index_mean = -200.0f;
     m_thermal_index_min = -200.0f;
     m_thermal_index_max = -200.0f;
+    m_warpage_fields.fill(NAN);
     {
         const std::string& raw = line.raw();
         auto pos = raw.find(";helioadditive=");
@@ -4607,6 +4634,12 @@ void GCodeProcessor::process_G2_G3(const GCodeReader::GCodeLine& line, bool cloc
                 m_thermal_index_min = static_cast<float>(std::atof(match[2].str().c_str())) * 100.0f;
                 m_thermal_index_mean = static_cast<float>(std::atof(match[3].str().c_str())) * 100.0f;
                 m_is_helio_gcode = true;
+            }
+            const std::array<const char*, 9> keys = { "wdm", "wdx", "wdy", "wdz", "wr", "wtg", "wts", "whs", "wls" };
+            for (size_t i = 0; i < keys.size(); ++i) {
+                const std::regex field_re(std::string("(?:^|,)") + keys[i] + "=(-?[0-9]*\\.?[0-9]+)");
+                if (std::regex_search(comment_str, match, field_re))
+                    m_warpage_fields[i] = static_cast<float>(std::atof(match[1].str().c_str()));
             }
         }
     }
@@ -5761,6 +5794,15 @@ void GCodeProcessor::store_move_vertex(EMoveType type, EMovePathType path_type, 
         m_thermal_index_mean,
         m_thermal_index_min,
         m_thermal_index_max,
+        m_warpage_fields[0],
+        m_warpage_fields[1],
+        m_warpage_fields[2],
+        m_warpage_fields[3],
+        m_warpage_fields[4],
+        m_warpage_fields[5],
+        m_warpage_fields[6],
+        m_warpage_fields[7],
+        m_warpage_fields[8],
         { 0.0f, 0.0f }, // time
         static_cast<float>(m_layer_id), //layer_duration: set later
         std::max<unsigned int>(1, m_layer_id) - 1,

--- a/src/libslic3r/GCode/GCodeProcessor.cpp
+++ b/src/libslic3r/GCode/GCodeProcessor.cpp
@@ -1710,6 +1710,8 @@ void GCodeProcessorResult::reset() {
     filament_change_count_map.clear();
     warnings.clear();
     is_helio_gcode = false;
+    warpage_wdm_p95 = NAN;
+    warpage_whs_p95 = NAN;
 
     //BBS: add mutex for protection of gcode result
     unlock();
@@ -3189,6 +3191,16 @@ void GCodeProcessor::process_tags(const std::string_view comment, bool producers
 
     // Helio thermal index and warpage fields are handled while processing moves so
     // they are available before the corresponding vertex is stored.
+
+    auto parse_warpage_percentile = [this, comment](const std::string_view prefix, float& value) {
+        if (!boost::starts_with(comment, prefix))
+            return false;
+        parse_number(comment.substr(prefix.size()), value);
+        return true;
+    };
+    if (parse_warpage_percentile(" WARPAGE_WDM_P95=", m_result.warpage_wdm_p95) ||
+        parse_warpage_percentile(" WARPAGE_WHS_P95=", m_result.warpage_whs_p95))
+        return;
 
     // wipe start tag
     if (boost::starts_with(comment, reserved_tag(ETags::Wipe_Start))) {

--- a/src/libslic3r/GCode/GCodeProcessor.hpp
+++ b/src/libslic3r/GCode/GCodeProcessor.hpp
@@ -14,6 +14,7 @@
 #include <string>
 #include <string_view>
 #include <optional>
+#include <cmath>
 
 namespace Slic3r {
 
@@ -171,6 +172,13 @@ class Print;
         FilamentPrintableResult filament_printable_reuslt;
         float initial_layer_time;
         bool is_helio_gcode{false};
+        float warpage_shrinkage_x_pct{ NAN };
+        float warpage_shrinkage_y_pct{ NAN };
+        float warpage_shrinkage_z_pct{ NAN };
+        float warpage_max_displacement_mm{ NAN };
+        float warpage_max_hull_shrinkage_um{ NAN };
+        float warpage_wdm_p95{ NAN };
+        float warpage_whs_p95{ NAN };
 
         struct SettingsIds
         {
@@ -212,6 +220,15 @@ class Print;
             float thermal_index_mean{ -200.0f };
             float thermal_index_min{ -200.0f };
             float thermal_index_max{ -200.0f };
+            float warpage_displacement{ NAN };
+            float warpage_disp_x{ NAN };
+            float warpage_disp_y{ NAN };
+            float warpage_disp_z{ NAN };
+            float warpage_risk{ NAN };
+            float warpage_ti_gradient{ NAN };
+            float warpage_thermal_strain{ NAN };
+            float warpage_hull_shrinkage{ NAN };
+            float warpage_layer_shrinkage{ NAN };
             std::array<float, static_cast<size_t>(PrintEstimatedStatistics::ETimeMode::Count)> time{ 0.0f, 0.0f }; // s
             float layer_duration{ 0.0f }; // s
             unsigned int layer_id{ 0 };
@@ -319,6 +336,13 @@ class Print;
             filament_change_count_map = other.filament_change_count_map;
             initial_layer_time = other.initial_layer_time;
             is_helio_gcode = other.is_helio_gcode;
+            warpage_shrinkage_x_pct = other.warpage_shrinkage_x_pct;
+            warpage_shrinkage_y_pct = other.warpage_shrinkage_y_pct;
+            warpage_shrinkage_z_pct = other.warpage_shrinkage_z_pct;
+            warpage_max_displacement_mm = other.warpage_max_displacement_mm;
+            warpage_max_hull_shrinkage_um = other.warpage_max_hull_shrinkage_um;
+            warpage_wdm_p95 = other.warpage_wdm_p95;
+            warpage_whs_p95 = other.warpage_whs_p95;
 #if ENABLE_GCODE_VIEWER_STATISTICS
             time = other.time;
 #endif
@@ -835,6 +859,7 @@ class Print;
         float m_thermal_index_mean{ -200.0f };
         float m_thermal_index_min{ -200.0f };
         float m_thermal_index_max{ -200.0f };
+        std::array<float, 9> m_warpage_fields{ NAN, NAN, NAN, NAN, NAN, NAN, NAN, NAN, NAN };
         bool m_is_helio_gcode{false};
         ExtrusionRole m_extrusion_role;
         std::vector<int> m_filament_maps;
@@ -1170,5 +1195,3 @@ class Print;
 } /* namespace Slic3r */
 
 #endif /* slic3r_GCodeProcessor_hpp_ */
-
-

--- a/src/libslic3r/GCode/GCodeProcessor.hpp
+++ b/src/libslic3r/GCode/GCodeProcessor.hpp
@@ -172,13 +172,6 @@ class Print;
         FilamentPrintableResult filament_printable_reuslt;
         float initial_layer_time;
         bool is_helio_gcode{false};
-        float warpage_shrinkage_x_pct{ NAN };
-        float warpage_shrinkage_y_pct{ NAN };
-        float warpage_shrinkage_z_pct{ NAN };
-        float warpage_max_displacement_mm{ NAN };
-        float warpage_max_hull_shrinkage_um{ NAN };
-        float warpage_wdm_p95{ NAN };
-        float warpage_whs_p95{ NAN };
 
         struct SettingsIds
         {
@@ -336,13 +329,6 @@ class Print;
             filament_change_count_map = other.filament_change_count_map;
             initial_layer_time = other.initial_layer_time;
             is_helio_gcode = other.is_helio_gcode;
-            warpage_shrinkage_x_pct = other.warpage_shrinkage_x_pct;
-            warpage_shrinkage_y_pct = other.warpage_shrinkage_y_pct;
-            warpage_shrinkage_z_pct = other.warpage_shrinkage_z_pct;
-            warpage_max_displacement_mm = other.warpage_max_displacement_mm;
-            warpage_max_hull_shrinkage_um = other.warpage_max_hull_shrinkage_um;
-            warpage_wdm_p95 = other.warpage_wdm_p95;
-            warpage_whs_p95 = other.warpage_whs_p95;
 #if ENABLE_GCODE_VIEWER_STATISTICS
             time = other.time;
 #endif

--- a/src/libslic3r/GCode/GCodeProcessor.hpp
+++ b/src/libslic3r/GCode/GCodeProcessor.hpp
@@ -172,6 +172,8 @@ class Print;
         FilamentPrintableResult filament_printable_reuslt;
         float initial_layer_time;
         bool is_helio_gcode{false};
+        float warpage_wdm_p95{ NAN };
+        float warpage_whs_p95{ NAN };
 
         struct SettingsIds
         {
@@ -329,6 +331,8 @@ class Print;
             filament_change_count_map = other.filament_change_count_map;
             initial_layer_time = other.initial_layer_time;
             is_helio_gcode = other.is_helio_gcode;
+            warpage_wdm_p95 = other.warpage_wdm_p95;
+            warpage_whs_p95 = other.warpage_whs_p95;
 #if ENABLE_GCODE_VIEWER_STATISTICS
             time = other.time;
 #endif

--- a/src/libvgcode/include/ColorRange.hpp
+++ b/src/libvgcode/include/ColorRange.hpp
@@ -11,6 +11,8 @@
 
 namespace libvgcode {
 
+struct ColorRangeTestAccess;
+
 static const Palette DEFAULT_RANGES_COLORS{ {
     {  11,  44, 122 }, // bluish
     {  19,  89, 133 },
@@ -100,6 +102,7 @@ private:
     void reset();
 
     friend class ViewerImpl;
+    friend struct ColorRangeTestAccess;
 };
 
 } // namespace libvgcode

--- a/src/libvgcode/include/GCodeInputData.hpp
+++ b/src/libvgcode/include/GCodeInputData.hpp
@@ -7,6 +7,8 @@
 
 #include "PathVertex.hpp"
 
+#include <limits>
+
 namespace libvgcode {
 
 struct GCodeInputData
@@ -29,6 +31,8 @@ struct GCodeInputData
     // Palette for color print colors
     //
     Palette color_print_colors;
+    float warpage_wdm_p95{ std::numeric_limits<float>::quiet_NaN() };
+    float warpage_whs_p95{ std::numeric_limits<float>::quiet_NaN() };
 };
 
 } // namespace libvgcode

--- a/src/libvgcode/include/PathVertex.hpp
+++ b/src/libvgcode/include/PathVertex.hpp
@@ -8,6 +8,7 @@
 #include "Types.hpp"
 
 #include <cfloat>
+#include <cmath>
 
 namespace libvgcode {
 
@@ -106,6 +107,15 @@ struct PathVertex
     float thermal_index_mean{ -200.0f };
     float thermal_index_min{ -200.0f };
     float thermal_index_max{ -200.0f };
+    float warpage_displacement{ NAN };
+    float warpage_disp_x{ NAN };
+    float warpage_disp_y{ NAN };
+    float warpage_disp_z{ NAN };
+    float warpage_risk{ NAN };
+    float warpage_ti_gradient{ NAN };
+    float warpage_thermal_strain{ NAN };
+    float warpage_hull_shrinkage{ NAN };
+    float warpage_layer_shrinkage{ NAN };
 
     //
     // Return true if the segment is an extrusion move

--- a/src/libvgcode/include/PathVertex.hpp
+++ b/src/libvgcode/include/PathVertex.hpp
@@ -12,6 +12,10 @@
 
 namespace libvgcode {
 
+// Warpage data originates outside the slicer. Treat NaN and infinities alike as
+// unavailable so malformed solver output cannot corrupt preview ranges or colors.
+inline bool is_valid_warpage_value(float value) { return std::isfinite(value); }
+
 //
 // Struct representating a gcode move (toolpath segment)
 //

--- a/src/libvgcode/include/Types.hpp
+++ b/src/libvgcode/include/Types.hpp
@@ -102,6 +102,15 @@ enum class EViewType : uint8_t
     ThermalIndexMean,
     ThermalIndexMin,
     ThermalIndexMax,
+    WarpageDisplacement,
+    WarpageDispX,
+    WarpageDispY,
+    WarpageDispZ,
+    WarpageRisk,
+    WarpageTIGradient,
+    WarpageThermalStrain,
+    WarpageHullShrinkage,
+    WarpageLayerShrinkage,
     Tool,
     COUNT
 };

--- a/src/libvgcode/src/ViewerImpl.cpp
+++ b/src/libvgcode/src/ViewerImpl.cpp
@@ -2017,6 +2017,16 @@ void ViewerImpl::update_color_ranges()
         }
     }
 
+    // Directional displacement uses a diverging palette, whose middle color must represent zero.
+    for (size_t i = 1; i <= 3; ++i) {
+        const std::array<float, 2>& range = m_warpage_ranges[i].get_range();
+        if (range[0] <= range[1]) {
+            const float extent = std::max(std::abs(range[0]), std::abs(range[1]));
+            m_warpage_ranges[i].update(-extent);
+            m_warpage_ranges[i].update(extent);
+        }
+    }
+
     const std::vector<float> times = m_layers.get_times(m_settings.time_mode);
     for (size_t i = 0; i < m_layer_time_range.size(); ++i) {
         for (float t : times) {

--- a/src/libvgcode/src/ViewerImpl.cpp
+++ b/src/libvgcode/src/ViewerImpl.cpp
@@ -1536,6 +1536,15 @@ Color ViewerImpl::get_vertex_color(const PathVertex& v) const
         if (v.thermal_index_max < -100.0f) return DUMMY_COLOR;
         return m_thermal_index_max_range.get_color_at(v.thermal_index_max);
     }
+    case EViewType::WarpageDisplacement: return std::isnan(v.warpage_displacement) ? DUMMY_COLOR : m_warpage_ranges[0].get_color_at(v.warpage_displacement);
+    case EViewType::WarpageDispX: return std::isnan(v.warpage_disp_x) ? DUMMY_COLOR : m_warpage_ranges[1].get_color_at(v.warpage_disp_x);
+    case EViewType::WarpageDispY: return std::isnan(v.warpage_disp_y) ? DUMMY_COLOR : m_warpage_ranges[2].get_color_at(v.warpage_disp_y);
+    case EViewType::WarpageDispZ: return std::isnan(v.warpage_disp_z) ? DUMMY_COLOR : m_warpage_ranges[3].get_color_at(v.warpage_disp_z);
+    case EViewType::WarpageRisk: return std::isnan(v.warpage_risk) ? DUMMY_COLOR : m_warpage_ranges[4].get_color_at(v.warpage_risk);
+    case EViewType::WarpageTIGradient: return std::isnan(v.warpage_ti_gradient) ? DUMMY_COLOR : m_warpage_ranges[5].get_color_at(v.warpage_ti_gradient);
+    case EViewType::WarpageThermalStrain: return std::isnan(v.warpage_thermal_strain) ? DUMMY_COLOR : m_warpage_ranges[6].get_color_at(v.warpage_thermal_strain);
+    case EViewType::WarpageHullShrinkage: return std::isnan(v.warpage_hull_shrinkage) ? DUMMY_COLOR : m_warpage_ranges[7].get_color_at(v.warpage_hull_shrinkage);
+    case EViewType::WarpageLayerShrinkage: return std::isnan(v.warpage_layer_shrinkage) ? DUMMY_COLOR : m_warpage_ranges[8].get_color_at(v.warpage_layer_shrinkage);
     case EViewType::VolumetricFlowRate:
     {
         return v.is_travel() ? get_option_color(move_type_to_option(v.type)) : m_volumetric_rate_range.get_color_at(v.volumetric_rate());
@@ -1634,6 +1643,15 @@ const ColorRange& ViewerImpl::get_color_range(EViewType type) const
     case EViewType::ThermalIndexMean:         { return m_thermal_index_mean_range; }
     case EViewType::ThermalIndexMin:          { return m_thermal_index_min_range; }
     case EViewType::ThermalIndexMax:          { return m_thermal_index_max_range; }
+    case EViewType::WarpageDisplacement: return m_warpage_ranges[0];
+    case EViewType::WarpageDispX: return m_warpage_ranges[1];
+    case EViewType::WarpageDispY: return m_warpage_ranges[2];
+    case EViewType::WarpageDispZ: return m_warpage_ranges[3];
+    case EViewType::WarpageRisk: return m_warpage_ranges[4];
+    case EViewType::WarpageTIGradient: return m_warpage_ranges[5];
+    case EViewType::WarpageThermalStrain: return m_warpage_ranges[6];
+    case EViewType::WarpageHullShrinkage: return m_warpage_ranges[7];
+    case EViewType::WarpageLayerShrinkage: return m_warpage_ranges[8];
     case EViewType::VolumetricFlowRate:       { return m_volumetric_rate_range; }
     case EViewType::ActualVolumetricFlowRate: { return m_actual_volumetric_rate_range; }
     case EViewType::LayerTimeLinear:          { return m_layer_time_range[0]; }
@@ -1661,6 +1679,15 @@ void ViewerImpl::set_color_range_palette(EViewType type, const Palette& palette)
     case EViewType::ThermalIndexMean:         { m_thermal_index_mean_range.set_palette(palette); break; }
     case EViewType::ThermalIndexMin:          { m_thermal_index_min_range.set_palette(palette); break; }
     case EViewType::ThermalIndexMax:          { m_thermal_index_max_range.set_palette(palette); break; }
+    case EViewType::WarpageDisplacement: m_warpage_ranges[0].set_palette(palette); break;
+    case EViewType::WarpageDispX: m_warpage_ranges[1].set_palette(palette); break;
+    case EViewType::WarpageDispY: m_warpage_ranges[2].set_palette(palette); break;
+    case EViewType::WarpageDispZ: m_warpage_ranges[3].set_palette(palette); break;
+    case EViewType::WarpageRisk: m_warpage_ranges[4].set_palette(palette); break;
+    case EViewType::WarpageTIGradient: m_warpage_ranges[5].set_palette(palette); break;
+    case EViewType::WarpageThermalStrain: m_warpage_ranges[6].set_palette(palette); break;
+    case EViewType::WarpageHullShrinkage: m_warpage_ranges[7].set_palette(palette); break;
+    case EViewType::WarpageLayerShrinkage: m_warpage_ranges[8].set_palette(palette); break;
     case EViewType::VolumetricFlowRate:       { m_volumetric_rate_range.set_palette(palette); break; }
     case EViewType::ActualVolumetricFlowRate: { m_actual_volumetric_rate_range.set_palette(palette); break; }
     case EViewType::LayerTimeLinear:          { m_layer_time_range[0].set_palette(palette);   break; }
@@ -1707,6 +1734,8 @@ size_t ViewerImpl::get_used_cpu_memory() const
     ret += m_thermal_index_mean_range.size_in_bytes_cpu();
     ret += m_thermal_index_min_range.size_in_bytes_cpu();
     ret += m_thermal_index_max_range.size_in_bytes_cpu();
+    for (const ColorRange& range : m_warpage_ranges)
+        ret += range.size_in_bytes_cpu();
     ret += m_volumetric_rate_range.size_in_bytes_cpu();
     ret += m_actual_volumetric_rate_range.size_in_bytes_cpu();
     for (size_t i = 0; i < COLOR_RANGE_TYPES_COUNT; ++i) {
@@ -1866,6 +1895,8 @@ void ViewerImpl::update_color_ranges()
     m_thermal_index_mean_range.reset();
     m_thermal_index_min_range.reset();
     m_thermal_index_max_range.reset();
+    for (ColorRange& range : m_warpage_ranges)
+        range.reset();
     // Helio: Use custom TI palette (blue→green→red) matching BambuStudio
     static const Palette TI_PALETTE{ {
         {  11,  44, 122 },  // #0b2c7a  -100 (blue)
@@ -1883,6 +1914,17 @@ void ViewerImpl::update_color_ranges()
     m_thermal_index_mean_range.set_palette(TI_PALETTE);
     m_thermal_index_min_range.set_palette(TI_PALETTE);
     m_thermal_index_max_range.set_palette(TI_PALETTE);
+    static const Palette WARPAGE_SEQUENTIAL{ {
+        { 30, 180, 60 }, { 140, 190, 40 }, { 220, 180, 30 }, { 230, 100, 20 }, { 200, 20, 20 }
+    } };
+    static const Palette WARPAGE_DIVERGING{ { { 0, 60, 200 }, { 30, 180, 60 }, { 200, 20, 20 } } };
+    static const Palette WARPAGE_DARK{ { { 25, 30, 50 }, { 30, 160, 60 }, { 220, 180, 30 }, { 200, 20, 20 } } };
+    for (ColorRange& range : m_warpage_ranges)
+        range.set_palette(WARPAGE_SEQUENTIAL);
+    m_warpage_ranges[1].set_palette(WARPAGE_DIVERGING);
+    m_warpage_ranges[2].set_palette(WARPAGE_DIVERGING);
+    m_warpage_ranges[3].set_palette(WARPAGE_DIVERGING);
+    m_warpage_ranges[7].set_palette(WARPAGE_DARK);
     // Anchor to fixed [-100, +100] so colors always match the legend
     m_thermal_index_mean_range.update(-100.0f);
     m_thermal_index_mean_range.update(100.0f);
@@ -1916,6 +1958,12 @@ void ViewerImpl::update_color_ranges()
                 m_thermal_index_min_range.update(v.thermal_index_min);
             if (v.thermal_index_max > -100.0f)
                 m_thermal_index_max_range.update(v.thermal_index_max);
+            const std::array<float, 9> warpage_values = { v.warpage_displacement, v.warpage_disp_x, v.warpage_disp_y,
+                v.warpage_disp_z, v.warpage_risk, v.warpage_ti_gradient, v.warpage_thermal_strain,
+                v.warpage_hull_shrinkage, v.warpage_layer_shrinkage };
+            for (size_t j = 0; j < warpage_values.size(); ++j)
+                if (!std::isnan(warpage_values[j]))
+                    m_warpage_ranges[j].update(warpage_values[j]);
         }
         if ((v.is_travel() && m_settings.options_visibility[size_t(EOptionType::Travels)]) ||
             (v.is_wipe() && m_settings.options_visibility[size_t(EOptionType::Wipes)]) ||

--- a/src/libvgcode/src/ViewerImpl.cpp
+++ b/src/libvgcode/src/ViewerImpl.cpp
@@ -1536,15 +1536,55 @@ Color ViewerImpl::get_vertex_color(const PathVertex& v) const
         if (v.thermal_index_max < -100.0f) return DUMMY_COLOR;
         return m_thermal_index_max_range.get_color_at(v.thermal_index_max);
     }
-    case EViewType::WarpageDisplacement: return std::isnan(v.warpage_displacement) ? DUMMY_COLOR : m_warpage_ranges[0].get_color_at(v.warpage_displacement);
-    case EViewType::WarpageDispX: return std::isnan(v.warpage_disp_x) ? DUMMY_COLOR : m_warpage_ranges[1].get_color_at(v.warpage_disp_x);
-    case EViewType::WarpageDispY: return std::isnan(v.warpage_disp_y) ? DUMMY_COLOR : m_warpage_ranges[2].get_color_at(v.warpage_disp_y);
-    case EViewType::WarpageDispZ: return std::isnan(v.warpage_disp_z) ? DUMMY_COLOR : m_warpage_ranges[3].get_color_at(v.warpage_disp_z);
-    case EViewType::WarpageRisk: return std::isnan(v.warpage_risk) ? DUMMY_COLOR : m_warpage_ranges[4].get_color_at(v.warpage_risk);
-    case EViewType::WarpageTIGradient: return std::isnan(v.warpage_ti_gradient) ? DUMMY_COLOR : m_warpage_ranges[5].get_color_at(v.warpage_ti_gradient);
-    case EViewType::WarpageThermalStrain: return std::isnan(v.warpage_thermal_strain) ? DUMMY_COLOR : m_warpage_ranges[6].get_color_at(v.warpage_thermal_strain);
-    case EViewType::WarpageHullShrinkage: return std::isnan(v.warpage_hull_shrinkage) ? DUMMY_COLOR : m_warpage_ranges[7].get_color_at(v.warpage_hull_shrinkage);
-    case EViewType::WarpageLayerShrinkage: return std::isnan(v.warpage_layer_shrinkage) ? DUMMY_COLOR : m_warpage_ranges[8].get_color_at(v.warpage_layer_shrinkage);
+    // Helio: Warpage visualization. Travel moves carry no simulation data, so they take the
+    // configured travel colour rather than DUMMY_COLOR — matching the thermal index views above
+    // and every other range view in this function. Without this, a travel and an extrusion whose
+    // metric is absent are both grey and cannot be told apart.
+    case EViewType::WarpageDisplacement:
+    {
+        if (v.is_travel()) return get_option_color(move_type_to_option(v.type));
+        return std::isnan(v.warpage_displacement) ? DUMMY_COLOR : m_warpage_ranges[0].get_color_at(v.warpage_displacement);
+    }
+    case EViewType::WarpageDispX:
+    {
+        if (v.is_travel()) return get_option_color(move_type_to_option(v.type));
+        return std::isnan(v.warpage_disp_x) ? DUMMY_COLOR : m_warpage_ranges[1].get_color_at(v.warpage_disp_x);
+    }
+    case EViewType::WarpageDispY:
+    {
+        if (v.is_travel()) return get_option_color(move_type_to_option(v.type));
+        return std::isnan(v.warpage_disp_y) ? DUMMY_COLOR : m_warpage_ranges[2].get_color_at(v.warpage_disp_y);
+    }
+    case EViewType::WarpageDispZ:
+    {
+        if (v.is_travel()) return get_option_color(move_type_to_option(v.type));
+        return std::isnan(v.warpage_disp_z) ? DUMMY_COLOR : m_warpage_ranges[3].get_color_at(v.warpage_disp_z);
+    }
+    case EViewType::WarpageRisk:
+    {
+        if (v.is_travel()) return get_option_color(move_type_to_option(v.type));
+        return std::isnan(v.warpage_risk) ? DUMMY_COLOR : m_warpage_ranges[4].get_color_at(v.warpage_risk);
+    }
+    case EViewType::WarpageTIGradient:
+    {
+        if (v.is_travel()) return get_option_color(move_type_to_option(v.type));
+        return std::isnan(v.warpage_ti_gradient) ? DUMMY_COLOR : m_warpage_ranges[5].get_color_at(v.warpage_ti_gradient);
+    }
+    case EViewType::WarpageThermalStrain:
+    {
+        if (v.is_travel()) return get_option_color(move_type_to_option(v.type));
+        return std::isnan(v.warpage_thermal_strain) ? DUMMY_COLOR : m_warpage_ranges[6].get_color_at(v.warpage_thermal_strain);
+    }
+    case EViewType::WarpageHullShrinkage:
+    {
+        if (v.is_travel()) return get_option_color(move_type_to_option(v.type));
+        return std::isnan(v.warpage_hull_shrinkage) ? DUMMY_COLOR : m_warpage_ranges[7].get_color_at(v.warpage_hull_shrinkage);
+    }
+    case EViewType::WarpageLayerShrinkage:
+    {
+        if (v.is_travel()) return get_option_color(move_type_to_option(v.type));
+        return std::isnan(v.warpage_layer_shrinkage) ? DUMMY_COLOR : m_warpage_ranges[8].get_color_at(v.warpage_layer_shrinkage);
+    }
     case EViewType::VolumetricFlowRate:
     {
         return v.is_travel() ? get_option_color(move_type_to_option(v.type)) : m_volumetric_rate_range.get_color_at(v.volumetric_rate());

--- a/src/libvgcode/src/ViewerImpl.cpp
+++ b/src/libvgcode/src/ViewerImpl.cpp
@@ -995,6 +995,8 @@ void ViewerImpl::load(GCodeInputData&& gcode_data)
     m_vertices = std::move(gcode_data.vertices);
     m_tool_colors = std::move(gcode_data.tools_colors);
     m_color_print_colors = std::move(gcode_data.color_print_colors);
+    m_warpage_wdm_p95 = gcode_data.warpage_wdm_p95;
+    m_warpage_whs_p95 = gcode_data.warpage_whs_p95;
     m_vertices_colors.resize(m_vertices.size());
 
     m_settings.spiral_vase_mode = gcode_data.spiral_vase_mode;
@@ -1964,7 +1966,22 @@ void ViewerImpl::update_color_ranges()
     m_warpage_ranges[1].set_palette(WARPAGE_DIVERGING);
     m_warpage_ranges[2].set_palette(WARPAGE_DIVERGING);
     m_warpage_ranges[3].set_palette(WARPAGE_DIVERGING);
+    m_warpage_ranges[5].set_palette(WARPAGE_DIVERGING);
     m_warpage_ranges[7].set_palette(WARPAGE_DARK);
+    m_warpage_ranges[4].update(0.0f);
+    m_warpage_ranges[4].update(1.0f);
+    if (!std::isnan(m_warpage_wdm_p95)) {
+        m_warpage_ranges[0].update(0.0f);
+        m_warpage_ranges[0].update(m_warpage_wdm_p95);
+        for (size_t i = 1; i <= 3; ++i) {
+            m_warpage_ranges[i].update(-m_warpage_wdm_p95);
+            m_warpage_ranges[i].update(m_warpage_wdm_p95);
+        }
+    }
+    if (!std::isnan(m_warpage_whs_p95)) {
+        m_warpage_ranges[7].update(0.0f);
+        m_warpage_ranges[7].update(m_warpage_whs_p95);
+    }
     // Anchor to fixed [-100, +100] so colors always match the legend
     m_thermal_index_mean_range.update(-100.0f);
     m_thermal_index_mean_range.update(100.0f);
@@ -2002,7 +2019,9 @@ void ViewerImpl::update_color_ranges()
                 v.warpage_disp_z, v.warpage_risk, v.warpage_ti_gradient, v.warpage_thermal_strain,
                 v.warpage_hull_shrinkage, v.warpage_layer_shrinkage };
             for (size_t j = 0; j < warpage_values.size(); ++j)
-                if (!std::isnan(warpage_values[j]))
+                if (!std::isnan(warpage_values[j]) && j != 4 &&
+                    (std::isnan(m_warpage_wdm_p95) || j > 3) &&
+                    (std::isnan(m_warpage_whs_p95) || j != 7))
                     m_warpage_ranges[j].update(warpage_values[j]);
         }
         if ((v.is_travel() && m_settings.options_visibility[size_t(EOptionType::Travels)]) ||
@@ -2014,16 +2033,6 @@ void ViewerImpl::update_color_ranges()
             m_acceleration_range.update(v.acceleration);
             // ORCA: Add Jerk visualization support
             m_jerk_range.update(v.jerk);
-        }
-    }
-
-    // Directional displacement uses a diverging palette, whose middle color must represent zero.
-    for (size_t i = 1; i <= 3; ++i) {
-        const std::array<float, 2>& range = m_warpage_ranges[i].get_range();
-        if (range[0] <= range[1]) {
-            const float extent = std::max(std::abs(range[0]), std::abs(range[1]));
-            m_warpage_ranges[i].update(-extent);
-            m_warpage_ranges[i].update(extent);
         }
     }
 

--- a/src/libvgcode/src/ViewerImpl.cpp
+++ b/src/libvgcode/src/ViewerImpl.cpp
@@ -1970,7 +1970,9 @@ void ViewerImpl::update_color_ranges()
     m_warpage_ranges[7].set_palette(WARPAGE_DARK);
     m_warpage_ranges[4].update(0.0f);
     m_warpage_ranges[4].update(1.0f);
-    if (!std::isnan(m_warpage_wdm_p95)) {
+    const bool has_wdm_p95 = std::isfinite(m_warpage_wdm_p95) && m_warpage_wdm_p95 > 0.0f;
+    const bool has_whs_p95 = std::isfinite(m_warpage_whs_p95) && m_warpage_whs_p95 > 0.0f;
+    if (has_wdm_p95) {
         m_warpage_ranges[0].update(0.0f);
         m_warpage_ranges[0].update(m_warpage_wdm_p95);
         for (size_t i = 1; i <= 3; ++i) {
@@ -1978,7 +1980,7 @@ void ViewerImpl::update_color_ranges()
             m_warpage_ranges[i].update(m_warpage_wdm_p95);
         }
     }
-    if (!std::isnan(m_warpage_whs_p95)) {
+    if (has_whs_p95) {
         m_warpage_ranges[7].update(0.0f);
         m_warpage_ranges[7].update(m_warpage_whs_p95);
     }
@@ -2020,8 +2022,8 @@ void ViewerImpl::update_color_ranges()
                 v.warpage_hull_shrinkage, v.warpage_layer_shrinkage };
             for (size_t j = 0; j < warpage_values.size(); ++j)
                 if (!std::isnan(warpage_values[j]) && j != 4 &&
-                    (std::isnan(m_warpage_wdm_p95) || j > 3) &&
-                    (std::isnan(m_warpage_whs_p95) || j != 7))
+                    (!has_wdm_p95 || j > 3) &&
+                    (!has_whs_p95 || j != 7))
                     m_warpage_ranges[j].update(warpage_values[j]);
         }
         if ((v.is_travel() && m_settings.options_visibility[size_t(EOptionType::Travels)]) ||

--- a/src/libvgcode/src/ViewerImpl.cpp
+++ b/src/libvgcode/src/ViewerImpl.cpp
@@ -1545,47 +1545,47 @@ Color ViewerImpl::get_vertex_color(const PathVertex& v) const
     case EViewType::WarpageDisplacement:
     {
         if (v.is_travel()) return get_option_color(move_type_to_option(v.type));
-        return std::isnan(v.warpage_displacement) ? DUMMY_COLOR : m_warpage_ranges[0].get_color_at(v.warpage_displacement);
+        return !is_valid_warpage_value(v.warpage_displacement) ? DUMMY_COLOR : m_warpage_ranges[0].get_color_at(v.warpage_displacement);
     }
     case EViewType::WarpageDispX:
     {
         if (v.is_travel()) return get_option_color(move_type_to_option(v.type));
-        return std::isnan(v.warpage_disp_x) ? DUMMY_COLOR : m_warpage_ranges[1].get_color_at(v.warpage_disp_x);
+        return !is_valid_warpage_value(v.warpage_disp_x) ? DUMMY_COLOR : m_warpage_ranges[1].get_color_at(v.warpage_disp_x);
     }
     case EViewType::WarpageDispY:
     {
         if (v.is_travel()) return get_option_color(move_type_to_option(v.type));
-        return std::isnan(v.warpage_disp_y) ? DUMMY_COLOR : m_warpage_ranges[2].get_color_at(v.warpage_disp_y);
+        return !is_valid_warpage_value(v.warpage_disp_y) ? DUMMY_COLOR : m_warpage_ranges[2].get_color_at(v.warpage_disp_y);
     }
     case EViewType::WarpageDispZ:
     {
         if (v.is_travel()) return get_option_color(move_type_to_option(v.type));
-        return std::isnan(v.warpage_disp_z) ? DUMMY_COLOR : m_warpage_ranges[3].get_color_at(v.warpage_disp_z);
+        return !is_valid_warpage_value(v.warpage_disp_z) ? DUMMY_COLOR : m_warpage_ranges[3].get_color_at(v.warpage_disp_z);
     }
     case EViewType::WarpageRisk:
     {
         if (v.is_travel()) return get_option_color(move_type_to_option(v.type));
-        return std::isnan(v.warpage_risk) ? DUMMY_COLOR : m_warpage_ranges[4].get_color_at(v.warpage_risk);
+        return !is_valid_warpage_value(v.warpage_risk) ? DUMMY_COLOR : m_warpage_ranges[4].get_color_at(v.warpage_risk);
     }
     case EViewType::WarpageTIGradient:
     {
         if (v.is_travel()) return get_option_color(move_type_to_option(v.type));
-        return std::isnan(v.warpage_ti_gradient) ? DUMMY_COLOR : m_warpage_ranges[5].get_color_at(v.warpage_ti_gradient);
+        return !is_valid_warpage_value(v.warpage_ti_gradient) ? DUMMY_COLOR : m_warpage_ranges[5].get_color_at(v.warpage_ti_gradient);
     }
     case EViewType::WarpageThermalStrain:
     {
         if (v.is_travel()) return get_option_color(move_type_to_option(v.type));
-        return std::isnan(v.warpage_thermal_strain) ? DUMMY_COLOR : m_warpage_ranges[6].get_color_at(v.warpage_thermal_strain);
+        return !is_valid_warpage_value(v.warpage_thermal_strain) ? DUMMY_COLOR : m_warpage_ranges[6].get_color_at(v.warpage_thermal_strain);
     }
     case EViewType::WarpageHullShrinkage:
     {
         if (v.is_travel()) return get_option_color(move_type_to_option(v.type));
-        return std::isnan(v.warpage_hull_shrinkage) ? DUMMY_COLOR : m_warpage_ranges[7].get_color_at(v.warpage_hull_shrinkage);
+        return !is_valid_warpage_value(v.warpage_hull_shrinkage) ? DUMMY_COLOR : m_warpage_ranges[7].get_color_at(v.warpage_hull_shrinkage);
     }
     case EViewType::WarpageLayerShrinkage:
     {
         if (v.is_travel()) return get_option_color(move_type_to_option(v.type));
-        return std::isnan(v.warpage_layer_shrinkage) ? DUMMY_COLOR : m_warpage_ranges[8].get_color_at(v.warpage_layer_shrinkage);
+        return !is_valid_warpage_value(v.warpage_layer_shrinkage) ? DUMMY_COLOR : m_warpage_ranges[8].get_color_at(v.warpage_layer_shrinkage);
     }
     case EViewType::VolumetricFlowRate:
     {
@@ -2021,7 +2021,7 @@ void ViewerImpl::update_color_ranges()
                 v.warpage_disp_z, v.warpage_risk, v.warpage_ti_gradient, v.warpage_thermal_strain,
                 v.warpage_hull_shrinkage, v.warpage_layer_shrinkage };
             for (size_t j = 0; j < warpage_values.size(); ++j)
-                if (!std::isnan(warpage_values[j]) && j != 4 &&
+                if (is_valid_warpage_value(warpage_values[j]) && j != 4 &&
                     (!has_wdm_p95 || j > 3) &&
                     (!has_whs_p95 || j != 7))
                     m_warpage_ranges[j].update(warpage_values[j]);

--- a/src/libvgcode/src/ViewerImpl.hpp
+++ b/src/libvgcode/src/ViewerImpl.hpp
@@ -299,6 +299,7 @@ private:
     ColorRange m_thermal_index_mean_range;
     ColorRange m_thermal_index_min_range;
     ColorRange m_thermal_index_max_range;
+    std::array<ColorRange, 9> m_warpage_ranges;
     ColorRange m_volumetric_rate_range;
     ColorRange m_actual_volumetric_rate_range;
     std::array<ColorRange, COLOR_RANGE_TYPES_COUNT> m_layer_time_range{

--- a/src/libvgcode/src/ViewerImpl.hpp
+++ b/src/libvgcode/src/ViewerImpl.hpp
@@ -22,6 +22,7 @@
 
 #include <string>
 #include <optional>
+#include <limits>
 
 namespace libvgcode {
 
@@ -300,6 +301,8 @@ private:
     ColorRange m_thermal_index_min_range;
     ColorRange m_thermal_index_max_range;
     std::array<ColorRange, 9> m_warpage_ranges;
+    float m_warpage_wdm_p95{ std::numeric_limits<float>::quiet_NaN() };
+    float m_warpage_whs_p95{ std::numeric_limits<float>::quiet_NaN() };
     ColorRange m_volumetric_rate_range;
     ColorRange m_actual_volumetric_rate_range;
     std::array<ColorRange, COLOR_RANGE_TYPES_COUNT> m_layer_time_range{

--- a/src/slic3r/GUI/GCodeViewer.cpp
+++ b/src/slic3r/GUI/GCodeViewer.cpp
@@ -152,6 +152,9 @@ static float warpage_value(const libvgcode::PathVertex& vertex, libvgcode::EView
 
 static void update_warpage_availability(const libvgcode::PathVertex& vertex, std::array<bool, 9>& availability)
 {
+    if (!vertex.is_extrusion())
+        return;
+
     const auto values = warpage_values(vertex);
     for (size_t i = 0; i < values.size(); ++i)
         availability[i] = availability[i] || !std::isnan(values[i]);

--- a/src/slic3r/GUI/GCodeViewer.cpp
+++ b/src/slic3r/GUI/GCodeViewer.cpp
@@ -107,6 +107,15 @@ static std::string get_view_type_string(libvgcode::EViewType view_type)
         return _u8L("Thermal Index (min)");
     else if (view_type == libvgcode::EViewType::ThermalIndexMax)
         return _u8L("Thermal Index (max)");
+    else if (view_type == libvgcode::EViewType::WarpageDisplacement) return _u8L("Warpage displacement");
+    else if (view_type == libvgcode::EViewType::WarpageDispX) return _u8L("Warpage displacement X");
+    else if (view_type == libvgcode::EViewType::WarpageDispY) return _u8L("Warpage displacement Y");
+    else if (view_type == libvgcode::EViewType::WarpageDispZ) return _u8L("Warpage displacement Z");
+    else if (view_type == libvgcode::EViewType::WarpageRisk) return _u8L("Warpage risk");
+    else if (view_type == libvgcode::EViewType::WarpageTIGradient) return _u8L("Warpage TI gradient");
+    else if (view_type == libvgcode::EViewType::WarpageThermalStrain) return _u8L("Warpage thermal strain");
+    else if (view_type == libvgcode::EViewType::WarpageHullShrinkage) return _u8L("Warpage hull shrinkage");
+    else if (view_type == libvgcode::EViewType::WarpageLayerShrinkage) return _u8L("Warpage layer shrinkage");
     return "";
 }
 
@@ -1195,6 +1204,17 @@ void GCodeViewer::update_by_mode(ConfigOptionMode mode)
         view_type_items.push_back(libvgcode::EViewType::ThermalIndexMin);
         view_type_items.push_back(libvgcode::EViewType::ThermalIndexMax);
     }
+    if (m_has_warpage_data) {
+        view_type_items.push_back(libvgcode::EViewType::WarpageDisplacement);
+        view_type_items.push_back(libvgcode::EViewType::WarpageDispX);
+        view_type_items.push_back(libvgcode::EViewType::WarpageDispY);
+        view_type_items.push_back(libvgcode::EViewType::WarpageDispZ);
+        view_type_items.push_back(libvgcode::EViewType::WarpageRisk);
+        view_type_items.push_back(libvgcode::EViewType::WarpageTIGradient);
+        view_type_items.push_back(libvgcode::EViewType::WarpageThermalStrain);
+        view_type_items.push_back(libvgcode::EViewType::WarpageHullShrinkage);
+        view_type_items.push_back(libvgcode::EViewType::WarpageLayerShrinkage);
+    }
     //if (mode == ConfigOptionMode::comDevelop) {
     //    view_type_items.push_back(EViewType::Tool);
     //}
@@ -1375,15 +1395,17 @@ void GCodeViewer::load_as_gcode(const GCodeProcessorResult& gcode_result, const 
     m_viewer.reset_default_extrusion_roles_colors();
     m_viewer.load(std::move(data));
 
-    // Helio: detect whether this gcode has any thermal index data
+    // Helio: expose simulation-only views only when their data is present.
     m_has_thermal_index_data = false;
+    m_has_warpage_data = false;
     {
         const size_t vcount = m_viewer.get_vertices_count();
         for (size_t i = 0; i < vcount; ++i) {
-            if (m_viewer.get_vertex_at(i).thermal_index_mean > -100.0f) {
-                m_has_thermal_index_data = true;
+            const libvgcode::PathVertex& vertex = m_viewer.get_vertex_at(i);
+            m_has_thermal_index_data |= vertex.thermal_index_mean > -100.0f;
+            m_has_warpage_data |= !std::isnan(vertex.warpage_displacement);
+            if (m_has_thermal_index_data && m_has_warpage_data)
                 break;
-            }
         }
     }
     update_by_mode(wxGetApp().get_mode());
@@ -1678,15 +1700,17 @@ void GCodeViewer::load_as_preview(libvgcode::GCodeInputData&& data)
     m_viewer.set_extrusion_role_color(libvgcode::EGCodeExtrusionRole::WipeTower,                { 127, 255, 127 });
     m_viewer.load(std::move(data));
 
-    // Helio: detect whether this gcode has any thermal index data
+    // Helio: expose simulation-only views only when their data is present.
     m_has_thermal_index_data = false;
+    m_has_warpage_data = false;
     {
         const size_t vcount = m_viewer.get_vertices_count();
         for (size_t i = 0; i < vcount; ++i) {
-            if (m_viewer.get_vertex_at(i).thermal_index_mean > -100.0f) {
-                m_has_thermal_index_data = true;
+            const libvgcode::PathVertex& vertex = m_viewer.get_vertex_at(i);
+            m_has_thermal_index_data |= vertex.thermal_index_mean > -100.0f;
+            m_has_warpage_data |= !std::isnan(vertex.warpage_displacement);
+            if (m_has_thermal_index_data && m_has_warpage_data)
                 break;
-            }
         }
     }
     update_by_mode(wxGetApp().get_mode());
@@ -3892,6 +3916,15 @@ void GCodeViewer::render_legend(float &legend_height, int canvas_width, int canv
         { imgui.title(_u8L("Thermal Index (min)")); break; }
     case libvgcode::EViewType::ThermalIndexMax:
         { imgui.title(_u8L("Thermal Index (max)")); break; }
+    case libvgcode::EViewType::WarpageDisplacement: { imgui.title(_u8L("Warpage displacement (mm)")); break; }
+    case libvgcode::EViewType::WarpageDispX: { imgui.title(_u8L("Warpage displacement X (mm)")); break; }
+    case libvgcode::EViewType::WarpageDispY: { imgui.title(_u8L("Warpage displacement Y (mm)")); break; }
+    case libvgcode::EViewType::WarpageDispZ: { imgui.title(_u8L("Warpage displacement Z (mm)")); break; }
+    case libvgcode::EViewType::WarpageRisk: { imgui.title(_u8L("Warpage risk")); break; }
+    case libvgcode::EViewType::WarpageTIGradient: { imgui.title(_u8L("Warpage TI gradient")); break; }
+    case libvgcode::EViewType::WarpageThermalStrain: { imgui.title(_u8L("Warpage thermal strain")); break; }
+    case libvgcode::EViewType::WarpageHullShrinkage: { imgui.title(_u8L("Warpage hull shrinkage")); break; }
+    case libvgcode::EViewType::WarpageLayerShrinkage: { imgui.title(_u8L("Warpage layer shrinkage")); break; }
 
     case libvgcode::EViewType::Tool:
     {
@@ -4221,6 +4254,17 @@ void GCodeViewer::render_legend(float &legend_height, int canvas_width, int canv
 
         break;
     }
+    case libvgcode::EViewType::WarpageDisplacement:
+    case libvgcode::EViewType::WarpageDispX:
+    case libvgcode::EViewType::WarpageDispY:
+    case libvgcode::EViewType::WarpageDispZ:
+    case libvgcode::EViewType::WarpageRisk:
+    case libvgcode::EViewType::WarpageTIGradient:
+    case libvgcode::EViewType::WarpageThermalStrain:
+    case libvgcode::EViewType::WarpageHullShrinkage:
+    case libvgcode::EViewType::WarpageLayerShrinkage:
+        append_range(m_viewer.get_color_range(curr_view_type), 4);
+        break;
     case libvgcode::EViewType::Tool:
     {
         // shows only extruders actually used
@@ -4953,4 +4997,3 @@ void GCodeViewer::render_slider(int canvas_width, int canvas_height) {
 
 } // namespace GUI
 } // namespace Slic3r
-

--- a/src/slic3r/GUI/GCodeViewer.cpp
+++ b/src/slic3r/GUI/GCodeViewer.cpp
@@ -119,6 +119,19 @@ static std::string get_view_type_string(libvgcode::EViewType view_type)
     return "";
 }
 
+static bool is_thermal_view(libvgcode::EViewType view_type)
+{
+    return view_type == libvgcode::EViewType::ThermalIndexMean ||
+           view_type == libvgcode::EViewType::ThermalIndexMin ||
+           view_type == libvgcode::EViewType::ThermalIndexMax;
+}
+
+static bool is_warpage_view(libvgcode::EViewType view_type)
+{
+    return view_type >= libvgcode::EViewType::WarpageDisplacement &&
+           view_type <= libvgcode::EViewType::WarpageLayerShrinkage;
+}
+
 // Find an index of a value in a sorted vector, which is in <z-eps, z+eps>.
 // Returns -1 if there is no such member.
 static int find_close_layer_idx(const std::vector<double> &zs, double &z, double eps)
@@ -1484,17 +1497,16 @@ void GCodeViewer::load_as_gcode(const GCodeProcessorResult& gcode_result, const 
     // load_toolpaths(gcode_result, build_volume, exclude_bounding_box);
     
     // ORCA: Apply smart default view type when extruder count changes.
-    // Helio: preserve ThermalIndex view type across plate switches / gcode reloads
+    // Helio: preserve simulation view types across plate switches / G-code reloads.
     const auto cur_vt = get_view_type();
-    bool is_thermal_view = (cur_vt == libvgcode::EViewType::ThermalIndexMean ||
-                            cur_vt == libvgcode::EViewType::ThermalIndexMin ||
-                            cur_vt == libvgcode::EViewType::ThermalIndexMax);
-    if (is_thermal_view && m_has_thermal_index_data) {
+    const bool thermal_view = is_thermal_view(cur_vt);
+    const bool warpage_view = is_warpage_view(cur_vt);
+    if ((thermal_view && m_has_thermal_index_data) || (warpage_view && m_has_warpage_data)) {
         auto it = std::find(view_type_items.begin(), view_type_items.end(), cur_vt);
         if (it != view_type_items.end())
             m_view_type_sel = std::distance(view_type_items.begin(), it);
         set_view_type(cur_vt);
-    } else if (is_thermal_view) {
+    } else if (thermal_view || warpage_view) {
         auto it = std::find(view_type_items.begin(), view_type_items.end(), libvgcode::EViewType::FeatureType);
         if (it != view_type_items.end())
             m_view_type_sel = std::distance(view_type_items.begin(), it);
@@ -1617,21 +1629,19 @@ void GCodeViewer::load_as_gcode(const GCodeProcessorResult& gcode_result, const 
             m_viewer.set_time_mode(libvgcode::convert(PrintEstimatedStatistics::ETimeMode::Normal));
     }
 
-    // Helio: preserve ThermalIndex view type if the loaded data contains TI.
+    // Helio: preserve simulation view types if the loaded data contains them.
     // NOTE: the multi-extruder ColorPrint defaulting deliberately lives ONLY in
     // the block near the top of this function, which is gated by
     // m_last_extruder_count_default_applied so it applies once per extruder-count
     // change and then respects the user's manual view choice. Do not re-assert
     // ColorPrint here — an unconditional override would fire on every reload/plate
-    // switch and defeat that sentinel. This block only handles the TI case.
+    // switch and defeat that sentinel. This block only handles simulation views.
     {
         const auto cur_vt2 = get_view_type();
-        bool is_thermal2 = (cur_vt2 == libvgcode::EViewType::ThermalIndexMean ||
-                            cur_vt2 == libvgcode::EViewType::ThermalIndexMin ||
-                            cur_vt2 == libvgcode::EViewType::ThermalIndexMax);
-        if (is_thermal2 && m_has_thermal_index_data) {
-            // TI view with data — keep it
-        } else if (is_thermal2) {
+        const bool unavailable_simulation_view =
+            (is_thermal_view(cur_vt2) && !m_has_thermal_index_data) ||
+            (is_warpage_view(cur_vt2) && !m_has_warpage_data);
+        if (unavailable_simulation_view) {
             for (int i = 0; i < view_type_items.size(); i++) {
                 if (view_type_items[i] == libvgcode::EViewType::FeatureType) {
                     m_view_type_sel = i;
@@ -1714,6 +1724,14 @@ void GCodeViewer::load_as_preview(libvgcode::GCodeInputData&& data)
         }
     }
     update_by_mode(wxGetApp().get_mode());
+
+    const auto current_view = get_view_type();
+    if ((is_thermal_view(current_view) && !m_has_thermal_index_data) ||
+        (is_warpage_view(current_view) && !m_has_warpage_data)) {
+        const auto it = std::find(view_type_items.begin(), view_type_items.end(), libvgcode::EViewType::FeatureType);
+        m_view_type_sel = it == view_type_items.end() ? 0 : std::distance(view_type_items.begin(), it);
+        set_view_type(libvgcode::EViewType::FeatureType);
+    }
 
     const libvgcode::AABox bbox = m_viewer.get_extrusion_bounding_box();
     const BoundingBoxf3 paths_bounding_box(libvgcode::convert(bbox[0]).cast<double>(), libvgcode::convert(bbox[1]).cast<double>());

--- a/src/slic3r/GUI/GCodeViewer.cpp
+++ b/src/slic3r/GUI/GCodeViewer.cpp
@@ -132,6 +132,15 @@ static bool is_warpage_view(libvgcode::EViewType view_type)
            view_type <= libvgcode::EViewType::WarpageLayerShrinkage;
 }
 
+static bool has_warpage_data(const libvgcode::PathVertex& vertex)
+{
+    return !std::isnan(vertex.warpage_displacement) || !std::isnan(vertex.warpage_disp_x) ||
+           !std::isnan(vertex.warpage_disp_y) || !std::isnan(vertex.warpage_disp_z) ||
+           !std::isnan(vertex.warpage_risk) || !std::isnan(vertex.warpage_ti_gradient) ||
+           !std::isnan(vertex.warpage_thermal_strain) || !std::isnan(vertex.warpage_hull_shrinkage) ||
+           !std::isnan(vertex.warpage_layer_shrinkage);
+}
+
 // Find an index of a value in a sorted vector, which is in <z-eps, z+eps>.
 // Returns -1 if there is no such member.
 static int find_close_layer_idx(const std::vector<double> &zs, double &z, double eps)
@@ -1416,7 +1425,7 @@ void GCodeViewer::load_as_gcode(const GCodeProcessorResult& gcode_result, const 
         for (size_t i = 0; i < vcount; ++i) {
             const libvgcode::PathVertex& vertex = m_viewer.get_vertex_at(i);
             m_has_thermal_index_data |= vertex.thermal_index_mean > -100.0f;
-            m_has_warpage_data |= !std::isnan(vertex.warpage_displacement);
+            m_has_warpage_data |= has_warpage_data(vertex);
             if (m_has_thermal_index_data && m_has_warpage_data)
                 break;
         }
@@ -1718,7 +1727,7 @@ void GCodeViewer::load_as_preview(libvgcode::GCodeInputData&& data)
         for (size_t i = 0; i < vcount; ++i) {
             const libvgcode::PathVertex& vertex = m_viewer.get_vertex_at(i);
             m_has_thermal_index_data |= vertex.thermal_index_mean > -100.0f;
-            m_has_warpage_data |= !std::isnan(vertex.warpage_displacement);
+            m_has_warpage_data |= has_warpage_data(vertex);
             if (m_has_thermal_index_data && m_has_warpage_data)
                 break;
         }

--- a/src/slic3r/GUI/GCodeViewer.cpp
+++ b/src/slic3r/GUI/GCodeViewer.cpp
@@ -132,13 +132,34 @@ static bool is_warpage_view(libvgcode::EViewType view_type)
            view_type <= libvgcode::EViewType::WarpageLayerShrinkage;
 }
 
-static bool has_warpage_data(const libvgcode::PathVertex& vertex)
+static size_t warpage_view_index(libvgcode::EViewType view_type)
 {
-    return !std::isnan(vertex.warpage_displacement) || !std::isnan(vertex.warpage_disp_x) ||
-           !std::isnan(vertex.warpage_disp_y) || !std::isnan(vertex.warpage_disp_z) ||
-           !std::isnan(vertex.warpage_risk) || !std::isnan(vertex.warpage_ti_gradient) ||
-           !std::isnan(vertex.warpage_thermal_strain) || !std::isnan(vertex.warpage_hull_shrinkage) ||
-           !std::isnan(vertex.warpage_layer_shrinkage);
+    assert(is_warpage_view(view_type));
+    return static_cast<size_t>(view_type) - static_cast<size_t>(libvgcode::EViewType::WarpageDisplacement);
+}
+
+static std::array<float, 9> warpage_values(const libvgcode::PathVertex& vertex)
+{
+    return { vertex.warpage_displacement, vertex.warpage_disp_x, vertex.warpage_disp_y,
+             vertex.warpage_disp_z, vertex.warpage_risk, vertex.warpage_ti_gradient,
+             vertex.warpage_thermal_strain, vertex.warpage_hull_shrinkage, vertex.warpage_layer_shrinkage };
+}
+
+static float warpage_value(const libvgcode::PathVertex& vertex, libvgcode::EViewType view_type)
+{
+    return warpage_values(vertex)[warpage_view_index(view_type)];
+}
+
+static void update_warpage_availability(const libvgcode::PathVertex& vertex, std::array<bool, 9>& availability)
+{
+    const auto values = warpage_values(vertex);
+    for (size_t i = 0; i < values.size(); ++i)
+        availability[i] = availability[i] || !std::isnan(values[i]);
+}
+
+static bool has_warpage_data(const std::array<bool, 9>& availability, libvgcode::EViewType view_type)
+{
+    return is_warpage_view(view_type) && availability[warpage_view_index(view_type)];
 }
 
 // Find an index of a value in a sorted vector, which is in <z-eps, z+eps>.
@@ -467,6 +488,22 @@ void GCodeViewer::SequentialView::Marker::render_position_window(const libvgcode
                 else
                     sprintf(detail_buf, "%s%s", _u8L("TI Max: ").c_str(), "null");
                 break;
+            case libvgcode::EViewType::WarpageDisplacement:
+            case libvgcode::EViewType::WarpageDispX:
+            case libvgcode::EViewType::WarpageDispY:
+            case libvgcode::EViewType::WarpageDispZ:
+            case libvgcode::EViewType::WarpageRisk:
+            case libvgcode::EViewType::WarpageTIGradient:
+            case libvgcode::EViewType::WarpageThermalStrain:
+            case libvgcode::EViewType::WarpageHullShrinkage:
+            case libvgcode::EViewType::WarpageLayerShrinkage: {
+                const float value = warpage_value(vertex, view_type);
+                if (is_extrusion && !std::isnan(value))
+                    sprintf(detail_buf, "%s: %.4f", get_view_type_string(view_type).c_str(), value);
+                else
+                    sprintf(detail_buf, "%s: %s", get_view_type_string(view_type).c_str(), NA_CSTR);
+                break;
+            }
             default:
                 detail_buf[0] = '\0';
                 break;
@@ -1226,17 +1263,11 @@ void GCodeViewer::update_by_mode(ConfigOptionMode mode)
         view_type_items.push_back(libvgcode::EViewType::ThermalIndexMin);
         view_type_items.push_back(libvgcode::EViewType::ThermalIndexMax);
     }
-    if (m_has_warpage_data) {
-        view_type_items.push_back(libvgcode::EViewType::WarpageDisplacement);
-        view_type_items.push_back(libvgcode::EViewType::WarpageDispX);
-        view_type_items.push_back(libvgcode::EViewType::WarpageDispY);
-        view_type_items.push_back(libvgcode::EViewType::WarpageDispZ);
-        view_type_items.push_back(libvgcode::EViewType::WarpageRisk);
-        view_type_items.push_back(libvgcode::EViewType::WarpageTIGradient);
-        view_type_items.push_back(libvgcode::EViewType::WarpageThermalStrain);
-        view_type_items.push_back(libvgcode::EViewType::WarpageHullShrinkage);
-        view_type_items.push_back(libvgcode::EViewType::WarpageLayerShrinkage);
-    }
+    for (auto view_type = libvgcode::EViewType::WarpageDisplacement;
+         view_type <= libvgcode::EViewType::WarpageLayerShrinkage;
+         view_type = static_cast<libvgcode::EViewType>(static_cast<size_t>(view_type) + 1))
+        if (has_warpage_data(m_has_warpage_data, view_type))
+            view_type_items.push_back(view_type);
     //if (mode == ConfigOptionMode::comDevelop) {
     //    view_type_items.push_back(EViewType::Tool);
     //}
@@ -1419,14 +1450,14 @@ void GCodeViewer::load_as_gcode(const GCodeProcessorResult& gcode_result, const 
 
     // Helio: expose simulation-only views only when their data is present.
     m_has_thermal_index_data = false;
-    m_has_warpage_data = false;
+    m_has_warpage_data.fill(false);
     {
         const size_t vcount = m_viewer.get_vertices_count();
         for (size_t i = 0; i < vcount; ++i) {
             const libvgcode::PathVertex& vertex = m_viewer.get_vertex_at(i);
             m_has_thermal_index_data |= vertex.thermal_index_mean > -100.0f;
-            m_has_warpage_data |= has_warpage_data(vertex);
-            if (m_has_thermal_index_data && m_has_warpage_data)
+            update_warpage_availability(vertex, m_has_warpage_data);
+            if (m_has_thermal_index_data && std::all_of(m_has_warpage_data.begin(), m_has_warpage_data.end(), [](bool available) { return available; }))
                 break;
         }
     }
@@ -1510,7 +1541,7 @@ void GCodeViewer::load_as_gcode(const GCodeProcessorResult& gcode_result, const 
     const auto cur_vt = get_view_type();
     const bool thermal_view = is_thermal_view(cur_vt);
     const bool warpage_view = is_warpage_view(cur_vt);
-    if ((thermal_view && m_has_thermal_index_data) || (warpage_view && m_has_warpage_data)) {
+    if ((thermal_view && m_has_thermal_index_data) || has_warpage_data(m_has_warpage_data, cur_vt)) {
         auto it = std::find(view_type_items.begin(), view_type_items.end(), cur_vt);
         if (it != view_type_items.end())
             m_view_type_sel = std::distance(view_type_items.begin(), it);
@@ -1649,7 +1680,7 @@ void GCodeViewer::load_as_gcode(const GCodeProcessorResult& gcode_result, const 
         const auto cur_vt2 = get_view_type();
         const bool unavailable_simulation_view =
             (is_thermal_view(cur_vt2) && !m_has_thermal_index_data) ||
-            (is_warpage_view(cur_vt2) && !m_has_warpage_data);
+            (is_warpage_view(cur_vt2) && !has_warpage_data(m_has_warpage_data, cur_vt2));
         if (unavailable_simulation_view) {
             for (int i = 0; i < view_type_items.size(); i++) {
                 if (view_type_items[i] == libvgcode::EViewType::FeatureType) {
@@ -1721,14 +1752,14 @@ void GCodeViewer::load_as_preview(libvgcode::GCodeInputData&& data)
 
     // Helio: expose simulation-only views only when their data is present.
     m_has_thermal_index_data = false;
-    m_has_warpage_data = false;
+    m_has_warpage_data.fill(false);
     {
         const size_t vcount = m_viewer.get_vertices_count();
         for (size_t i = 0; i < vcount; ++i) {
             const libvgcode::PathVertex& vertex = m_viewer.get_vertex_at(i);
             m_has_thermal_index_data |= vertex.thermal_index_mean > -100.0f;
-            m_has_warpage_data |= has_warpage_data(vertex);
-            if (m_has_thermal_index_data && m_has_warpage_data)
+            update_warpage_availability(vertex, m_has_warpage_data);
+            if (m_has_thermal_index_data && std::all_of(m_has_warpage_data.begin(), m_has_warpage_data.end(), [](bool available) { return available; }))
                 break;
         }
     }
@@ -1736,7 +1767,7 @@ void GCodeViewer::load_as_preview(libvgcode::GCodeInputData&& data)
 
     const auto current_view = get_view_type();
     if ((is_thermal_view(current_view) && !m_has_thermal_index_data) ||
-        (is_warpage_view(current_view) && !m_has_warpage_data)) {
+        (is_warpage_view(current_view) && !has_warpage_data(m_has_warpage_data, current_view))) {
         const auto it = std::find(view_type_items.begin(), view_type_items.end(), libvgcode::EViewType::FeatureType);
         m_view_type_sel = it == view_type_items.end() ? 0 : std::distance(view_type_items.begin(), it);
         set_view_type(libvgcode::EViewType::FeatureType);

--- a/src/slic3r/GUI/GCodeViewer.cpp
+++ b/src/slic3r/GUI/GCodeViewer.cpp
@@ -1451,19 +1451,7 @@ void GCodeViewer::load_as_gcode(const GCodeProcessorResult& gcode_result, const 
     m_viewer.reset_default_extrusion_roles_colors();
     m_viewer.load(std::move(data));
 
-    // Helio: expose simulation-only views only when their data is present.
-    m_has_thermal_index_data = false;
-    m_has_warpage_data.fill(false);
-    {
-        const size_t vcount = m_viewer.get_vertices_count();
-        for (size_t i = 0; i < vcount; ++i) {
-            const libvgcode::PathVertex& vertex = m_viewer.get_vertex_at(i);
-            m_has_thermal_index_data |= vertex.thermal_index_mean > -100.0f;
-            update_warpage_availability(vertex, m_has_warpage_data);
-            if (m_has_thermal_index_data && std::all_of(m_has_warpage_data.begin(), m_has_warpage_data.end(), [](bool available) { return available; }))
-                break;
-        }
-    }
+    update_simulation_data_availability();
     update_by_mode(wxGetApp().get_mode());
 
 // #if !VGCODE_ENABLE_COG_AND_TOOL_MARKERS
@@ -1717,6 +1705,21 @@ void GCodeViewer::load_as_gcode(const GCodeProcessorResult& gcode_result, const 
     wxGetApp().plater()->schedule_background_process();
 }
 
+void GCodeViewer::update_simulation_data_availability()
+{
+    m_has_thermal_index_data = false;
+    m_has_warpage_data.fill(false);
+    const size_t vertices_count = m_viewer.get_vertices_count();
+    for (size_t i = 0; i < vertices_count; ++i) {
+        const libvgcode::PathVertex& vertex = m_viewer.get_vertex_at(i);
+        m_has_thermal_index_data |= vertex.thermal_index_mean > -100.0f;
+        update_warpage_availability(vertex, m_has_warpage_data);
+        if (m_has_thermal_index_data &&
+            std::all_of(m_has_warpage_data.begin(), m_has_warpage_data.end(), [](bool available) { return available; }))
+            break;
+    }
+}
+
 void GCodeViewer::load_as_preview(libvgcode::GCodeInputData&& data)
 {
     m_loaded_as_preview = true;
@@ -1753,19 +1756,7 @@ void GCodeViewer::load_as_preview(libvgcode::GCodeInputData&& data)
     m_viewer.set_extrusion_role_color(libvgcode::EGCodeExtrusionRole::WipeTower,                { 127, 255, 127 });
     m_viewer.load(std::move(data));
 
-    // Helio: expose simulation-only views only when their data is present.
-    m_has_thermal_index_data = false;
-    m_has_warpage_data.fill(false);
-    {
-        const size_t vcount = m_viewer.get_vertices_count();
-        for (size_t i = 0; i < vcount; ++i) {
-            const libvgcode::PathVertex& vertex = m_viewer.get_vertex_at(i);
-            m_has_thermal_index_data |= vertex.thermal_index_mean > -100.0f;
-            update_warpage_availability(vertex, m_has_warpage_data);
-            if (m_has_thermal_index_data && std::all_of(m_has_warpage_data.begin(), m_has_warpage_data.end(), [](bool available) { return available; }))
-                break;
-        }
-    }
+    update_simulation_data_availability();
     update_by_mode(wxGetApp().get_mode());
 
     const auto current_view = get_view_type();

--- a/src/slic3r/GUI/GCodeViewer.cpp
+++ b/src/slic3r/GUI/GCodeViewer.cpp
@@ -1712,7 +1712,7 @@ void GCodeViewer::update_simulation_data_availability()
     const size_t vertices_count = m_viewer.get_vertices_count();
     for (size_t i = 0; i < vertices_count; ++i) {
         const libvgcode::PathVertex& vertex = m_viewer.get_vertex_at(i);
-        m_has_thermal_index_data |= vertex.thermal_index_mean > -100.0f;
+        m_has_thermal_index_data |= vertex.is_extrusion() && vertex.thermal_index_mean > -100.0f;
         update_warpage_availability(vertex, m_has_warpage_data);
         if (m_has_thermal_index_data &&
             std::all_of(m_has_warpage_data.begin(), m_has_warpage_data.end(), [](bool available) { return available; }))

--- a/src/slic3r/GUI/GCodeViewer.cpp
+++ b/src/slic3r/GUI/GCodeViewer.cpp
@@ -157,7 +157,7 @@ static void update_warpage_availability(const libvgcode::PathVertex& vertex, std
 
     const auto values = warpage_values(vertex);
     for (size_t i = 0; i < values.size(); ++i)
-        availability[i] = availability[i] || !std::isnan(values[i]);
+        availability[i] = availability[i] || libvgcode::is_valid_warpage_value(values[i]);
 }
 
 static bool has_warpage_data(const std::array<bool, 9>& availability, libvgcode::EViewType view_type)
@@ -501,7 +501,7 @@ void GCodeViewer::SequentialView::Marker::render_position_window(const libvgcode
             case libvgcode::EViewType::WarpageHullShrinkage:
             case libvgcode::EViewType::WarpageLayerShrinkage: {
                 const float value = warpage_value(vertex, view_type);
-                if (is_extrusion && !std::isnan(value))
+                if (is_extrusion && libvgcode::is_valid_warpage_value(value))
                     sprintf(detail_buf, "%s: %.4f", get_view_type_string(view_type).c_str(), value);
                 else
                     sprintf(detail_buf, "%s: %s", get_view_type_string(view_type).c_str(), NA_CSTR);

--- a/src/slic3r/GUI/GCodeViewer.hpp
+++ b/src/slic3r/GUI/GCodeViewer.hpp
@@ -253,6 +253,7 @@ mutable bool m_no_render_path { false };
     libvgcode::Viewer m_viewer;
     bool m_loaded_as_preview{ false };
     bool m_has_thermal_index_data{ false };
+    bool m_has_warpage_data{ false };
 
 public:
     GCodeViewer();
@@ -384,4 +385,3 @@ private:
 } // namespace Slic3r
 
 #endif // slic3r_GCodeViewer_hpp_
-

--- a/src/slic3r/GUI/GCodeViewer.hpp
+++ b/src/slic3r/GUI/GCodeViewer.hpp
@@ -253,7 +253,7 @@ mutable bool m_no_render_path { false };
     libvgcode::Viewer m_viewer;
     bool m_loaded_as_preview{ false };
     bool m_has_thermal_index_data{ false };
-    bool m_has_warpage_data{ false };
+    std::array<bool, 9> m_has_warpage_data{};
 
 public:
     GCodeViewer();

--- a/src/slic3r/GUI/GCodeViewer.hpp
+++ b/src/slic3r/GUI/GCodeViewer.hpp
@@ -254,6 +254,7 @@ mutable bool m_no_render_path { false };
     bool m_loaded_as_preview{ false };
     bool m_has_thermal_index_data{ false };
     std::array<bool, 9> m_has_warpage_data{};
+    void update_simulation_data_availability();
 
 public:
     GCodeViewer();

--- a/src/slic3r/GUI/HelioReleaseNote.cpp
+++ b/src/slic3r/GUI/HelioReleaseNote.cpp
@@ -883,6 +883,44 @@ void HelioStatementDialog::create_pat_page()
         content_sizer->Add(mm_row, 0, wxALIGN_CENTER, 0);
     }
 
+    content_sizer->Add(0, 0, 0, wxTOP, FromDIP(12));
+
+    // Warping-analysis feature toggle
+    {
+        wxBoxSizer* warping_row = new wxBoxSizer(wxHORIZONTAL);
+        auto* warping_checkbox = new ::CheckBox(page_pat_panel);
+
+        warping_checkbox->SetValue(wxGetApp().app_config->get_bool("helio_warping_analysis_enabled"));
+
+        auto* warping_label = new Label(page_pat_panel, Label::Body_13,
+            _L("Experimental: Enable warping analysis"));
+        warping_label->SetForegroundColour(HELIO_MUTED);
+        warping_label->SetToolTip(_L("When enabled, Helio performs warping analysis during simulations."));
+
+        auto save_warping_setting = [warping_checkbox]() {
+            const bool enabled = warping_checkbox->GetValue();
+            wxGetApp().app_config->set_bool("helio_warping_analysis_enabled", enabled);
+            wxGetApp().app_config->save();
+            BOOST_LOG_TRIVIAL(info) << "helio_warping_analysis_enabled set to " << (enabled ? "true" : "false");
+            warping_checkbox->Refresh(false);
+            warping_checkbox->Update();
+        };
+
+        warping_checkbox->Bind(wxEVT_TOGGLEBUTTON, [save_warping_setting](wxCommandEvent& e) {
+            save_warping_setting();
+            e.Skip();
+        });
+
+        warping_label->Bind(wxEVT_LEFT_DOWN, [warping_checkbox, save_warping_setting](wxMouseEvent&) {
+            warping_checkbox->SetValue(!warping_checkbox->GetValue());
+            save_warping_setting();
+        });
+
+        warping_row->Add(warping_checkbox, 0, wxALIGN_CENTER_VERTICAL, 0);
+        warping_row->Add(warping_label, 0, wxALIGN_CENTER_VERTICAL | wxLEFT, FromDIP(8));
+        content_sizer->Add(warping_row, 0, wxALIGN_CENTER, 0);
+    }
+
     content_sizer->Add(0, 0, 0, wxTOP, FromDIP(24));
     content_sizer->Add(helio_links_sizer, 0, wxALIGN_CENTER, 0);
     content_sizer->Add(0, 0, 0, wxTOP, FromDIP(20));

--- a/src/slic3r/GUI/LibVGCode/LibVGCodeWrapper.cpp
+++ b/src/slic3r/GUI/LibVGCode/LibVGCodeWrapper.cpp
@@ -228,7 +228,9 @@ GCodeInputData convert(const Slic3r::GCodeProcessorResult& result, const std::ve
                     /* ORCA: Add Pressure Advance visualization support */ 0.0f, curr.pressure_advance,
                     /* ORCA: Add Acceleration visualization support */ curr.acceleration,
                     /* ORCA: Add Jerk visualization support */ curr.jerk,
-            /* Helio: Thermal index from simulation */ curr.thermal_index_mean, curr.thermal_index_min, curr.thermal_index_max };
+            /* Helio: Thermal index from simulation */ curr.thermal_index_mean, curr.thermal_index_min, curr.thermal_index_max,
+            curr.warpage_displacement, curr.warpage_disp_x, curr.warpage_disp_y, curr.warpage_disp_z, curr.warpage_risk,
+            curr.warpage_ti_gradient, curr.warpage_thermal_strain, curr.warpage_hull_shrinkage, curr.warpage_layer_shrinkage };
 #else
               const libvgcode::PathVertex vertex = { convert(prev.position), curr.height, curr.width, curr.feedrate, prev.actual_feedrate,
                     curr.mm3_per_mm, curr.fan_speed, curr.temperature, convert(curr.extrusion_role), curr_type,
@@ -237,7 +239,9 @@ GCodeInputData convert(const Slic3r::GCodeProcessorResult& result, const std::ve
                     /* ORCA: Add Pressure Advance visualization support */ 0.0f, curr.pressure_advance,
                     /* ORCA: Add Acceleration visualization support */ curr.acceleration,
                     /* ORCA: Add Jerk visualization support */ curr.jerk,
-            /* Helio: Thermal index from simulation */ curr.thermal_index_mean, curr.thermal_index_min, curr.thermal_index_max };
+            /* Helio: Thermal index from simulation */ curr.thermal_index_mean, curr.thermal_index_min, curr.thermal_index_max,
+            curr.warpage_displacement, curr.warpage_disp_x, curr.warpage_disp_y, curr.warpage_disp_z, curr.warpage_risk,
+            curr.warpage_ti_gradient, curr.warpage_thermal_strain, curr.warpage_hull_shrinkage, curr.warpage_layer_shrinkage };
 #endif // VGCODE_ENABLE_COG_AND_TOOL_MARKERS
                 ret.vertices.emplace_back(vertex);
             }
@@ -252,7 +256,9 @@ GCodeInputData convert(const Slic3r::GCodeProcessorResult& result, const std::ve
             /* ORCA: Add Pressure Advance visualization support */ 0.0f, curr.pressure_advance,
             /* ORCA: Add Acceleration visualization support */ curr.acceleration,
             /* ORCA: Add Jerk visualization support */ curr.jerk,
-            /* Helio: Thermal index from simulation */ curr.thermal_index_mean, curr.thermal_index_min, curr.thermal_index_max };
+            /* Helio: Thermal index from simulation */ curr.thermal_index_mean, curr.thermal_index_min, curr.thermal_index_max,
+            curr.warpage_displacement, curr.warpage_disp_x, curr.warpage_disp_y, curr.warpage_disp_z, curr.warpage_risk,
+            curr.warpage_ti_gradient, curr.warpage_thermal_strain, curr.warpage_hull_shrinkage, curr.warpage_layer_shrinkage };
 #else
         const libvgcode::PathVertex vertex = { convert(curr.position), curr.height, curr.width, curr.feedrate, curr.actual_feedrate,
             curr.mm3_per_mm, curr.fan_speed, curr.temperature, convert(curr.extrusion_role), curr_type,
@@ -261,7 +267,9 @@ GCodeInputData convert(const Slic3r::GCodeProcessorResult& result, const std::ve
             /* ORCA: Add Pressure Advance visualization support */ 0.0f, curr.pressure_advance,
             /* ORCA: Add Acceleration visualization support */ curr.acceleration,
             /* ORCA: Add Jerk visualization support */ curr.jerk,
-            /* Helio: Thermal index from simulation */ curr.thermal_index_mean, curr.thermal_index_min, curr.thermal_index_max };
+            /* Helio: Thermal index from simulation */ curr.thermal_index_mean, curr.thermal_index_min, curr.thermal_index_max,
+            curr.warpage_displacement, curr.warpage_disp_x, curr.warpage_disp_y, curr.warpage_disp_z, curr.warpage_risk,
+            curr.warpage_ti_gradient, curr.warpage_thermal_strain, curr.warpage_hull_shrinkage, curr.warpage_layer_shrinkage };
 #endif // VGCODE_ENABLE_COG_AND_TOOL_MARKERS
         ret.vertices.emplace_back(vertex);
     }
@@ -834,4 +842,3 @@ GCodeInputData convert(const Slic3r::Print& print, const std::vector<std::string
 }
 
 } // namespace libvgcode
-

--- a/src/slic3r/GUI/LibVGCode/LibVGCodeWrapper.cpp
+++ b/src/slic3r/GUI/LibVGCode/LibVGCodeWrapper.cpp
@@ -192,6 +192,8 @@ GCodeInputData convert(const Slic3r::GCodeProcessorResult& result, const std::ve
     const std::vector<std::string>& str_color_print_colors, const Viewer& viewer)
 {
     GCodeInputData ret;
+    ret.warpage_wdm_p95 = result.warpage_wdm_p95;
+    ret.warpage_whs_p95 = result.warpage_whs_p95;
 
     // collect tool colors
     ret.tools_colors.reserve(str_tool_colors.size());

--- a/src/slic3r/GUI/Preferences.cpp
+++ b/src/slic3r/GUI/Preferences.cpp
@@ -2044,6 +2044,10 @@ void PreferencesDialog::create_items()
         _L("When enabled, Helio uses per-slot material mapping for multi-material plates"), "helio_multimaterial_enabled");
     g_sizer->Add(item_multimaterial);
 
+    auto item_warping_analysis = create_item_checkbox(_L("Experimental: Enable warping analysis"),
+        _L("When enabled, Helio performs warping analysis during simulations"), "helio_warping_analysis_enabled");
+    g_sizer->Add(item_warping_analysis);
+
     g_sizer->AddSpacer(FromDIP(10));
     sizer_page->Add(g_sizer, 0, wxEXPAND);
 

--- a/src/slic3r/Utils/HelioDragon.cpp
+++ b/src/slic3r/Utils/HelioDragon.cpp
@@ -1405,7 +1405,8 @@ std::string HelioQuery::generate_simulation_graphql_query(const std::string& gco
                                                           float              temperatureStabilizationHeight,
                                                           float              airTemperatureAboveBuildPlate,
                                                           float              stabilizedAirTemperature,
-                                                          const std::string& job_name)
+                                                          const std::string& job_name,
+                                                          bool               enableWarpingAnalysis)
 {
     CNumericLocalesSetter locales_setter;
     // Use a caller-supplied stable name when provided so create-retries reuse the same name
@@ -1422,6 +1423,9 @@ std::string HelioQuery::generate_simulation_graphql_query(const std::string& gco
     )";
 
     std::vector<std::string> settings_fields;
+
+    settings_fields.push_back(boost::str(boost::format(R"(                    "enableWarpingAnalysis": %1%)") %
+                                         (enableWarpingAnalysis ? "true" : "false")));
 
     if (temperatureStabilizationHeight != -1) {
         settings_fields.push_back(boost::str(boost::format(R"(                    "temperatureStabilizationHeight": %1%)") % temperatureStabilizationHeight));
@@ -1607,8 +1611,9 @@ HelioQuery::CreateSimulationResult HelioQuery::create_simulation(const std::stri
     const float object_proximity_airtemp_kelvin = chamber_temp == -1 ? -1 : chamber_temp + 273.15;
     const float layer_threshold_meters          = layer_threshold / 1000;
 
+    const bool enable_warping_analysis = GUI::wxGetApp().app_config->get_bool("helio_warping_analysis_enabled");
     std::string query_body = generate_simulation_graphql_query(gcode_id, layer_threshold_meters, initial_room_temp_kelvin,
-                                                               object_proximity_airtemp_kelvin, job_name);
+                                                               object_proximity_airtemp_kelvin, job_name, enable_warping_analysis);
 
     HelioQuery::CreateSimulationResult res;
     auto http = Http::post(helio_api_url);

--- a/src/slic3r/Utils/HelioDragon.cpp
+++ b/src/slic3r/Utils/HelioDragon.cpp
@@ -1424,8 +1424,10 @@ std::string HelioQuery::generate_simulation_graphql_query(const std::string& gco
 
     std::vector<std::string> settings_fields;
 
-    settings_fields.push_back(boost::str(boost::format(R"(                    "enableWarpingAnalysis": %1%)") %
-                                         (enableWarpingAnalysis ? "true" : "false")));
+    // Keep the disabled path compatible with regional API schemas that predate
+    // the experimental setting. An omitted field retains the server default.
+    if (enableWarpingAnalysis)
+        settings_fields.emplace_back(R"(                    "enableWarpingAnalysis": true)");
 
     if (temperatureStabilizationHeight != -1) {
         settings_fields.push_back(boost::str(boost::format(R"(                    "temperatureStabilizationHeight": %1%)") % temperatureStabilizationHeight));

--- a/src/slic3r/Utils/HelioDragon.hpp
+++ b/src/slic3r/Utils/HelioDragon.hpp
@@ -392,7 +392,8 @@ public:
                                                          float              temperatureStabilizationHeight = -1,
                                                          float              airTemperatureAboveBuildPlate  = -1,
                                                          float              stabilizedAirTemperature       = -1,
-                                                         const std::string& job_name                       = "");
+                                                         const std::string& job_name                       = "",
+                                                         bool               enableWarpingAnalysis          = false);
 
     static std::string generate_optimization_graphql_query(const std::string& gcode_id,
                                                            const std::string& printPriority,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -53,9 +53,9 @@ function(orcaslicer_discover_tests TARGET)
 endfunction()
 
 add_subdirectory(libnest2d)
+add_subdirectory(libvgcode)
 add_subdirectory(libslic3r)
 add_subdirectory(slic3rutils)
 add_subdirectory(fff_print)
 add_subdirectory(sla_print)
-
 

--- a/tests/libvgcode/CMakeLists.txt
+++ b/tests/libvgcode/CMakeLists.txt
@@ -1,0 +1,11 @@
+get_filename_component(_TEST_NAME ${CMAKE_CURRENT_LIST_DIR} NAME)
+
+add_executable(${_TEST_NAME}_tests
+    test_warpage_values.cpp
+)
+
+target_link_libraries(${_TEST_NAME}_tests test_common libvgcode Catch2::Catch2WithMain)
+set_property(TARGET ${_TEST_NAME}_tests PROPERTY FOLDER "tests")
+
+orcaslicer_copy_test_dlls()
+orcaslicer_discover_tests(${_TEST_NAME}_tests)

--- a/tests/libvgcode/test_warpage_values.cpp
+++ b/tests/libvgcode/test_warpage_values.cpp
@@ -1,0 +1,62 @@
+#include <catch2/catch_all.hpp>
+
+#include "libvgcode/include/ColorRange.hpp"
+#include "libvgcode/include/PathVertex.hpp"
+#include "libvgcode/include/Viewer.hpp"
+
+#include <array>
+#include <cmath>
+#include <limits>
+
+using namespace libvgcode;
+
+TEST_CASE("non-finite warpage values do not pollute color ranges", "[libvgcode][warpage]")
+{
+    ColorRange range;
+    const std::array<float, 4> values = {
+        0.02f, std::numeric_limits<float>::infinity(), 0.09f, 0.2f
+    };
+
+    for (float value : values) {
+        if (is_valid_warpage_value(value))
+            range.update(value);
+    }
+
+    REQUIRE(range.get_range() == std::array<float, 2>{ 0.02f, 0.2f });
+    for (float legend_value : range.get_values())
+        REQUIRE(std::isfinite(legend_value));
+}
+
+TEST_CASE("all nine warpage fields reject non-finite values", "[libvgcode][warpage]")
+{
+    const float infinity = std::numeric_limits<float>::infinity();
+    PathVertex vertex;
+    vertex.warpage_displacement = infinity;
+    vertex.warpage_disp_x = infinity;
+    vertex.warpage_disp_y = infinity;
+    vertex.warpage_disp_z = infinity;
+    vertex.warpage_risk = infinity;
+    vertex.warpage_ti_gradient = infinity;
+    vertex.warpage_thermal_strain = infinity;
+    vertex.warpage_hull_shrinkage = infinity;
+    vertex.warpage_layer_shrinkage = infinity;
+
+    const std::array<float, 9> values = {
+        vertex.warpage_displacement, vertex.warpage_disp_x, vertex.warpage_disp_y,
+        vertex.warpage_disp_z, vertex.warpage_risk, vertex.warpage_ti_gradient,
+        vertex.warpage_thermal_strain, vertex.warpage_hull_shrinkage, vertex.warpage_layer_shrinkage
+    };
+    for (float value : values)
+        REQUIRE_FALSE(is_valid_warpage_value(value));
+
+    Viewer viewer;
+    const std::array<EViewType, 9> view_types = {
+        EViewType::WarpageDisplacement, EViewType::WarpageDispX, EViewType::WarpageDispY,
+        EViewType::WarpageDispZ, EViewType::WarpageRisk, EViewType::WarpageTIGradient,
+        EViewType::WarpageThermalStrain, EViewType::WarpageHullShrinkage, EViewType::WarpageLayerShrinkage
+    };
+    for (EViewType view_type : view_types) {
+        viewer.set_view_type(view_type);
+        REQUIRE(viewer.get_vertex_color(vertex) == DUMMY_COLOR);
+    }
+}

--- a/tests/libvgcode/test_warpage_values.cpp
+++ b/tests/libvgcode/test_warpage_values.cpp
@@ -1,7 +1,6 @@
 #include <catch2/catch_all.hpp>
 
 #include "libvgcode/include/ColorRange.hpp"
-#include "libvgcode/include/GCodeInputData.hpp"
 #include "libvgcode/include/PathVertex.hpp"
 #include "libvgcode/include/Viewer.hpp"
 
@@ -11,23 +10,27 @@
 
 using namespace libvgcode;
 
+namespace libvgcode {
+
+struct ColorRangeTestAccess
+{
+    static void update(ColorRange& range, float value) { range.update(value); }
+};
+
+} // namespace libvgcode
+
 TEST_CASE("non-finite warpage values do not pollute color ranges", "[libvgcode][warpage]")
 {
+    ColorRange range;
     const std::array<float, 4> values = {
         0.02f, std::numeric_limits<float>::infinity(), 0.09f, 0.2f
     };
 
-    GCodeInputData gcode_data;
     for (float value : values) {
-        PathVertex vertex;
-        vertex.type = EMoveType::Extrude;
-        vertex.warpage_displacement = value;
-        gcode_data.vertices.emplace_back(vertex);
+        if (is_valid_warpage_value(value))
+            ColorRangeTestAccess::update(range, value);
     }
 
-    Viewer viewer;
-    viewer.load(std::move(gcode_data));
-    const ColorRange& range = viewer.get_color_range(EViewType::WarpageDisplacement);
     REQUIRE(range.get_range() == std::array<float, 2>{ 0.02f, 0.2f });
     for (float legend_value : range.get_values())
         REQUIRE(std::isfinite(legend_value));

--- a/tests/libvgcode/test_warpage_values.cpp
+++ b/tests/libvgcode/test_warpage_values.cpp
@@ -1,6 +1,7 @@
 #include <catch2/catch_all.hpp>
 
 #include "libvgcode/include/ColorRange.hpp"
+#include "libvgcode/include/GCodeInputData.hpp"
 #include "libvgcode/include/PathVertex.hpp"
 #include "libvgcode/include/Viewer.hpp"
 
@@ -12,16 +13,21 @@ using namespace libvgcode;
 
 TEST_CASE("non-finite warpage values do not pollute color ranges", "[libvgcode][warpage]")
 {
-    ColorRange range;
     const std::array<float, 4> values = {
         0.02f, std::numeric_limits<float>::infinity(), 0.09f, 0.2f
     };
 
+    GCodeInputData gcode_data;
     for (float value : values) {
-        if (is_valid_warpage_value(value))
-            range.update(value);
+        PathVertex vertex;
+        vertex.type = EMoveType::Extrude;
+        vertex.warpage_displacement = value;
+        gcode_data.vertices.emplace_back(vertex);
     }
 
+    Viewer viewer;
+    viewer.load(std::move(gcode_data));
+    const ColorRange& range = viewer.get_color_range(EViewType::WarpageDisplacement);
     REQUIRE(range.get_range() == std::array<float, 2>{ 0.02f, 0.2f });
     for (float legend_value : range.get_values())
         REQUIRE(std::isfinite(legend_value));


### PR DESCRIPTION
## Summary
- parse and propagate Helio warpage metrics from annotated G-code moves
- add nine warpage visualization modes, color ranges, selectors, and legends
- expose each warpage view whenever its supported metric is present
- add an opt-in **Experimental: Enable warping analysis** setting to both the activation-success page and Helio preferences
- send the setting as `simulationSettings.enableWarpingAnalysis` in Helio simulation requests; it remains disabled by default

## Testing
- `git show --check --oneline --stat HEAD`
- Full build not run because the checkout has no configured `build/CMakeCache.txt`.
