### PR TITLE
Add warpage fields to G-code preview

### DIFF
--- a/src/libslic3r/GCode/GCodeProcessor.cpp
+++ b/src/libslic3r/GCode/GCodeProcessor.cpp
@@ -3839,6 +3839,7 @@ void GCodeProcessor::process_G1(const GCodeReader::GCodeLine& line, const std::o
     m_thermal_index_mean = -200.0f;
     m_thermal_index_min = -200.0f;
     m_thermal_index_max = -200.0f;
+    m_warpage_fields.fill(NAN);
     {
         const std::string& raw = line.raw();
         auto pos = raw.find(";helioadditive=");
@@ -3851,6 +3852,20 @@ void GCodeProcessor::process_G1(const GCodeReader::GCodeLine& line, const std::o
                 m_thermal_index_min = static_cast<float>(std::atof(match[2].str().c_str())) * 100.0f;
                 m_thermal_index_mean = static_cast<float>(std::atof(match[3].str().c_str())) * 100.0f;
                 m_is_helio_gcode = true;
+            }
+
+            static constexpr std::array<std::string_view, 9> warpage_keys{
+                "wdm=", "wdx=", "wdy=", "wdz=", "wr=", "wtg=", "wts=", "whs=", "wls="
+            };
+            for (size_t i = 0; i < warpage_keys.size(); ++i) {
+                const size_t value_pos = raw.find(warpage_keys[i], pos);
+                if (value_pos == std::string::npos)
+                    continue;
+                const char *value_begin = raw.c_str() + value_pos + warpage_keys[i].size();
+                char *value_end = nullptr;
+                const float value = std::strtof(value_begin, &value_end);
+                if (value_end != value_begin)
+                    m_warpage_fields[i] = value;
             }
         }
     }
@@ -4595,6 +4610,7 @@ void GCodeProcessor::process_G2_G3(const GCodeReader::GCodeLine& line, bool cloc
     m_thermal_index_mean = -200.0f;
     m_thermal_index_min = -200.0f;
     m_thermal_index_max = -200.0f;
+    m_warpage_fields.fill(NAN);
     {
         const std::string& raw = line.raw();
         auto pos = raw.find(";helioadditive=");
@@ -4607,6 +4623,20 @@ void GCodeProcessor::process_G2_G3(const GCodeReader::GCodeLine& line, bool cloc
                 m_thermal_index_min = static_cast<float>(std::atof(match[2].str().c_str())) * 100.0f;
                 m_thermal_index_mean = static_cast<float>(std::atof(match[3].str().c_str())) * 100.0f;
                 m_is_helio_gcode = true;
+            }
+
+            static constexpr std::array<std::string_view, 9> warpage_keys{
+                "wdm=", "wdx=", "wdy=", "wdz=", "wr=", "wtg=", "wts=", "whs=", "wls="
+            };
+            for (size_t i = 0; i < warpage_keys.size(); ++i) {
+                const size_t value_pos = raw.find(warpage_keys[i], pos);
+                if (value_pos == std::string::npos)
+                    continue;
+                const char *value_begin = raw.c_str() + value_pos + warpage_keys[i].size();
+                char *value_end = nullptr;
+                const float value = std::strtof(value_begin, &value_end);
+                if (value_end != value_begin)
+                    m_warpage_fields[i] = value;
             }
         }
     }
@@ -5761,6 +5791,9 @@ void GCodeProcessor::store_move_vertex(EMoveType type, EMovePathType path_type, 
         m_thermal_index_mean,
         m_thermal_index_min,
         m_thermal_index_max,
+        m_warpage_fields[0], m_warpage_fields[1], m_warpage_fields[2],
+        m_warpage_fields[3], m_warpage_fields[4], m_warpage_fields[5],
+        m_warpage_fields[6], m_warpage_fields[7], m_warpage_fields[8],
         { 0.0f, 0.0f }, // time
         static_cast<float>(m_layer_id), //layer_duration: set later
         std::max<unsigned int>(1, m_layer_id) - 1,

--- a/src/libslic3r/GCode/GCodeProcessor.hpp
+++ b/src/libslic3r/GCode/GCodeProcessor.hpp
@@ -8,6 +8,7 @@
 #include "libslic3r/CustomGCode.hpp"
 
 #include <cstdint>
+#include <cmath>
 #include <array>
 #include <vector>
 #include <mutex>
@@ -212,6 +213,16 @@ class Print;
             float thermal_index_mean{ -200.0f };
             float thermal_index_min{ -200.0f };
             float thermal_index_max{ -200.0f };
+            // Helio warpage fields from the enhanced G-code comment. NaN means unavailable.
+            float warpage_displacement{ NAN };
+            float warpage_disp_x{ NAN };
+            float warpage_disp_y{ NAN };
+            float warpage_disp_z{ NAN };
+            float warpage_risk{ NAN };
+            float warpage_ti_gradient{ NAN };
+            float warpage_thermal_strain{ NAN };
+            float warpage_hull_shrinkage{ NAN };
+            float warpage_layer_shrinkage{ NAN };
             std::array<float, static_cast<size_t>(PrintEstimatedStatistics::ETimeMode::Count)> time{ 0.0f, 0.0f }; // s
             float layer_duration{ 0.0f }; // s
             unsigned int layer_id{ 0 };
@@ -835,6 +846,7 @@ class Print;
         float m_thermal_index_mean{ -200.0f };
         float m_thermal_index_min{ -200.0f };
         float m_thermal_index_max{ -200.0f };
+        std::array<float, 9> m_warpage_fields{ NAN, NAN, NAN, NAN, NAN, NAN, NAN, NAN, NAN };
         bool m_is_helio_gcode{false};
         ExtrusionRole m_extrusion_role;
         std::vector<int> m_filament_maps;

--- a/src/libvgcode/include/PathVertex.hpp
+++ b/src/libvgcode/include/PathVertex.hpp
@@ -8,6 +8,7 @@
 #include "Types.hpp"
 
 #include <cfloat>
+#include <cmath>
 
 namespace libvgcode {
 
@@ -106,6 +107,15 @@ struct PathVertex
     float thermal_index_mean{ -200.0f };
     float thermal_index_min{ -200.0f };
     float thermal_index_max{ -200.0f };
+    float warpage_displacement{ NAN };
+    float warpage_disp_x{ NAN };
+    float warpage_disp_y{ NAN };
+    float warpage_disp_z{ NAN };
+    float warpage_risk{ NAN };
+    float warpage_ti_gradient{ NAN };
+    float warpage_thermal_strain{ NAN };
+    float warpage_hull_shrinkage{ NAN };
+    float warpage_layer_shrinkage{ NAN };
 
     //
     // Return true if the segment is an extrusion move

--- a/src/libvgcode/include/Types.hpp
+++ b/src/libvgcode/include/Types.hpp
@@ -102,6 +102,15 @@ enum class EViewType : uint8_t
     ThermalIndexMean,
     ThermalIndexMin,
     ThermalIndexMax,
+    WarpageDisplacement,
+    WarpageDispX,
+    WarpageDispY,
+    WarpageDispZ,
+    WarpageRisk,
+    WarpageTIGradient,
+    WarpageThermalStrain,
+    WarpageHullShrinkage,
+    WarpageLayerShrinkage,
     Tool,
     COUNT
 };

--- a/src/libvgcode/src/ViewerImpl.cpp
+++ b/src/libvgcode/src/ViewerImpl.cpp
@@ -1536,6 +1536,15 @@ Color ViewerImpl::get_vertex_color(const PathVertex& v) const
         if (v.thermal_index_max < -100.0f) return DUMMY_COLOR;
         return m_thermal_index_max_range.get_color_at(v.thermal_index_max);
     }
+    case EViewType::WarpageDisplacement:  return std::isfinite(v.warpage_displacement) ? m_warpage_ranges[0].get_color_at(v.warpage_displacement) : DUMMY_COLOR;
+    case EViewType::WarpageDispX:         return std::isfinite(v.warpage_disp_x) ? m_warpage_ranges[1].get_color_at(v.warpage_disp_x) : DUMMY_COLOR;
+    case EViewType::WarpageDispY:         return std::isfinite(v.warpage_disp_y) ? m_warpage_ranges[2].get_color_at(v.warpage_disp_y) : DUMMY_COLOR;
+    case EViewType::WarpageDispZ:         return std::isfinite(v.warpage_disp_z) ? m_warpage_ranges[3].get_color_at(v.warpage_disp_z) : DUMMY_COLOR;
+    case EViewType::WarpageRisk:          return std::isfinite(v.warpage_risk) ? m_warpage_ranges[4].get_color_at(v.warpage_risk) : DUMMY_COLOR;
+    case EViewType::WarpageTIGradient:    return std::isfinite(v.warpage_ti_gradient) ? m_warpage_ranges[5].get_color_at(v.warpage_ti_gradient) : DUMMY_COLOR;
+    case EViewType::WarpageThermalStrain: return std::isfinite(v.warpage_thermal_strain) ? m_warpage_ranges[6].get_color_at(v.warpage_thermal_strain) : DUMMY_COLOR;
+    case EViewType::WarpageHullShrinkage: return std::isfinite(v.warpage_hull_shrinkage) ? m_warpage_ranges[7].get_color_at(v.warpage_hull_shrinkage) : DUMMY_COLOR;
+    case EViewType::WarpageLayerShrinkage:return std::isfinite(v.warpage_layer_shrinkage) ? m_warpage_ranges[8].get_color_at(v.warpage_layer_shrinkage) : DUMMY_COLOR;
     case EViewType::VolumetricFlowRate:
     {
         return v.is_travel() ? get_option_color(move_type_to_option(v.type)) : m_volumetric_rate_range.get_color_at(v.volumetric_rate());
@@ -1634,6 +1643,15 @@ const ColorRange& ViewerImpl::get_color_range(EViewType type) const
     case EViewType::ThermalIndexMean:         { return m_thermal_index_mean_range; }
     case EViewType::ThermalIndexMin:          { return m_thermal_index_min_range; }
     case EViewType::ThermalIndexMax:          { return m_thermal_index_max_range; }
+    case EViewType::WarpageDisplacement:     { return m_warpage_ranges[0]; }
+    case EViewType::WarpageDispX:            { return m_warpage_ranges[1]; }
+    case EViewType::WarpageDispY:            { return m_warpage_ranges[2]; }
+    case EViewType::WarpageDispZ:            { return m_warpage_ranges[3]; }
+    case EViewType::WarpageRisk:             { return m_warpage_ranges[4]; }
+    case EViewType::WarpageTIGradient:       { return m_warpage_ranges[5]; }
+    case EViewType::WarpageThermalStrain:    { return m_warpage_ranges[6]; }
+    case EViewType::WarpageHullShrinkage:    { return m_warpage_ranges[7]; }
+    case EViewType::WarpageLayerShrinkage:   { return m_warpage_ranges[8]; }
     case EViewType::VolumetricFlowRate:       { return m_volumetric_rate_range; }
     case EViewType::ActualVolumetricFlowRate: { return m_actual_volumetric_rate_range; }
     case EViewType::LayerTimeLinear:          { return m_layer_time_range[0]; }
@@ -1661,6 +1679,15 @@ void ViewerImpl::set_color_range_palette(EViewType type, const Palette& palette)
     case EViewType::ThermalIndexMean:         { m_thermal_index_mean_range.set_palette(palette); break; }
     case EViewType::ThermalIndexMin:          { m_thermal_index_min_range.set_palette(palette); break; }
     case EViewType::ThermalIndexMax:          { m_thermal_index_max_range.set_palette(palette); break; }
+    case EViewType::WarpageDisplacement: { m_warpage_ranges[0].set_palette(palette); break; }
+    case EViewType::WarpageDispX: { m_warpage_ranges[1].set_palette(palette); break; }
+    case EViewType::WarpageDispY: { m_warpage_ranges[2].set_palette(palette); break; }
+    case EViewType::WarpageDispZ: { m_warpage_ranges[3].set_palette(palette); break; }
+    case EViewType::WarpageRisk: { m_warpage_ranges[4].set_palette(palette); break; }
+    case EViewType::WarpageTIGradient: { m_warpage_ranges[5].set_palette(palette); break; }
+    case EViewType::WarpageThermalStrain: { m_warpage_ranges[6].set_palette(palette); break; }
+    case EViewType::WarpageHullShrinkage: { m_warpage_ranges[7].set_palette(palette); break; }
+    case EViewType::WarpageLayerShrinkage: { m_warpage_ranges[8].set_palette(palette); break; }
     case EViewType::VolumetricFlowRate:       { m_volumetric_rate_range.set_palette(palette); break; }
     case EViewType::ActualVolumetricFlowRate: { m_actual_volumetric_rate_range.set_palette(palette); break; }
     case EViewType::LayerTimeLinear:          { m_layer_time_range[0].set_palette(palette);   break; }
@@ -1707,6 +1734,8 @@ size_t ViewerImpl::get_used_cpu_memory() const
     ret += m_thermal_index_mean_range.size_in_bytes_cpu();
     ret += m_thermal_index_min_range.size_in_bytes_cpu();
     ret += m_thermal_index_max_range.size_in_bytes_cpu();
+    for (const ColorRange &range : m_warpage_ranges)
+        ret += range.size_in_bytes_cpu();
     ret += m_volumetric_rate_range.size_in_bytes_cpu();
     ret += m_actual_volumetric_rate_range.size_in_bytes_cpu();
     for (size_t i = 0; i < COLOR_RANGE_TYPES_COUNT; ++i) {
@@ -1866,6 +1895,8 @@ void ViewerImpl::update_color_ranges()
     m_thermal_index_mean_range.reset();
     m_thermal_index_min_range.reset();
     m_thermal_index_max_range.reset();
+    for (ColorRange &range : m_warpage_ranges)
+        range.reset();
     // Helio: Use custom TI palette (blue→green→red) matching BambuStudio
     static const Palette TI_PALETTE{ {
         {  11,  44, 122 },  // #0b2c7a  -100 (blue)
@@ -1883,6 +1914,14 @@ void ViewerImpl::update_color_ranges()
     m_thermal_index_mean_range.set_palette(TI_PALETTE);
     m_thermal_index_min_range.set_palette(TI_PALETTE);
     m_thermal_index_max_range.set_palette(TI_PALETTE);
+    static const Palette WARPAGE_PALETTE{ {
+        { 30, 180, 60 }, { 140, 190, 40 }, { 220, 180, 30 }, { 230, 100, 20 }, { 200, 20, 20 }
+    } };
+    static const Palette WARPAGE_DIVERGING_PALETTE{ {
+        { 0, 60, 200 }, { 30, 180, 60 }, { 200, 20, 20 }
+    } };
+    for (size_t i = 0; i < m_warpage_ranges.size(); ++i)
+        m_warpage_ranges[i].set_palette(i == 1 || i == 2 || i == 3 || i == 5 ? WARPAGE_DIVERGING_PALETTE : WARPAGE_PALETTE);
     // Anchor to fixed [-100, +100] so colors always match the legend
     m_thermal_index_mean_range.update(-100.0f);
     m_thermal_index_mean_range.update(100.0f);
@@ -1916,6 +1955,12 @@ void ViewerImpl::update_color_ranges()
                 m_thermal_index_min_range.update(v.thermal_index_min);
             if (v.thermal_index_max > -100.0f)
                 m_thermal_index_max_range.update(v.thermal_index_max);
+            const std::array<float, 9> warpage_values{ v.warpage_displacement, v.warpage_disp_x, v.warpage_disp_y,
+                v.warpage_disp_z, v.warpage_risk, v.warpage_ti_gradient, v.warpage_thermal_strain,
+                v.warpage_hull_shrinkage, v.warpage_layer_shrinkage };
+            for (size_t i = 0; i < warpage_values.size(); ++i)
+                if (std::isfinite(warpage_values[i]))
+                    m_warpage_ranges[i].update(warpage_values[i]);
         }
         if ((v.is_travel() && m_settings.options_visibility[size_t(EOptionType::Travels)]) ||
             (v.is_wipe() && m_settings.options_visibility[size_t(EOptionType::Wipes)]) ||

--- a/src/libvgcode/src/ViewerImpl.hpp
+++ b/src/libvgcode/src/ViewerImpl.hpp
@@ -299,6 +299,7 @@ private:
     ColorRange m_thermal_index_mean_range;
     ColorRange m_thermal_index_min_range;
     ColorRange m_thermal_index_max_range;
+    std::array<ColorRange, 9> m_warpage_ranges;
     ColorRange m_volumetric_rate_range;
     ColorRange m_actual_volumetric_rate_range;
     std::array<ColorRange, COLOR_RANGE_TYPES_COUNT> m_layer_time_range{

--- a/src/slic3r/GUI/GCodeViewer.cpp
+++ b/src/slic3r/GUI/GCodeViewer.cpp
@@ -107,6 +107,24 @@ static std::string get_view_type_string(libvgcode::EViewType view_type)
         return _u8L("Thermal Index (min)");
     else if (view_type == libvgcode::EViewType::ThermalIndexMax)
         return _u8L("Thermal Index (max)");
+    else if (view_type == libvgcode::EViewType::WarpageDisplacement)
+        return _u8L("Displacement");
+    else if (view_type == libvgcode::EViewType::WarpageDispX)
+        return _u8L("Displacement X");
+    else if (view_type == libvgcode::EViewType::WarpageDispY)
+        return _u8L("Displacement Y");
+    else if (view_type == libvgcode::EViewType::WarpageDispZ)
+        return _u8L("Displacement Z");
+    else if (view_type == libvgcode::EViewType::WarpageRisk)
+        return _u8L("Warpage Risk");
+    else if (view_type == libvgcode::EViewType::WarpageTIGradient)
+        return _u8L("TI Gradient");
+    else if (view_type == libvgcode::EViewType::WarpageThermalStrain)
+        return _u8L("Thermal Strain");
+    else if (view_type == libvgcode::EViewType::WarpageHullShrinkage)
+        return _u8L("Hull Shrinkage");
+    else if (view_type == libvgcode::EViewType::WarpageLayerShrinkage)
+        return _u8L("Layer Shrinkage");
     return "";
 }
 
@@ -435,6 +453,60 @@ void GCodeViewer::SequentialView::Marker::render_position_window(const libvgcode
                     sprintf(detail_buf, "%s%.1f", _u8L("TI Max: ").c_str(), vertex.thermal_index_max);
                 else
                     sprintf(detail_buf, "%s%s", _u8L("TI Max: ").c_str(), "null");
+                break;
+            case libvgcode::EViewType::WarpageDisplacement:
+                if (is_extrusion && std::isfinite(vertex.warpage_displacement))
+                    sprintf(detail_buf, "%s%.4f", _u8L("Displacement: ").c_str(), vertex.warpage_displacement);
+                else
+                    sprintf(detail_buf, "%s%s", _u8L("Displacement: ").c_str(), "null");
+                break;
+            case libvgcode::EViewType::WarpageDispX:
+                if (is_extrusion && std::isfinite(vertex.warpage_disp_x))
+                    sprintf(detail_buf, "%s%.4f", _u8L("Displacement X: ").c_str(), vertex.warpage_disp_x);
+                else
+                    sprintf(detail_buf, "%s%s", _u8L("Displacement X: ").c_str(), "null");
+                break;
+            case libvgcode::EViewType::WarpageDispY:
+                if (is_extrusion && std::isfinite(vertex.warpage_disp_y))
+                    sprintf(detail_buf, "%s%.4f", _u8L("Displacement Y: ").c_str(), vertex.warpage_disp_y);
+                else
+                    sprintf(detail_buf, "%s%s", _u8L("Displacement Y: ").c_str(), "null");
+                break;
+            case libvgcode::EViewType::WarpageDispZ:
+                if (is_extrusion && std::isfinite(vertex.warpage_disp_z))
+                    sprintf(detail_buf, "%s%.4f", _u8L("Displacement Z: ").c_str(), vertex.warpage_disp_z);
+                else
+                    sprintf(detail_buf, "%s%s", _u8L("Displacement Z: ").c_str(), "null");
+                break;
+            case libvgcode::EViewType::WarpageRisk:
+                if (is_extrusion && std::isfinite(vertex.warpage_risk))
+                    sprintf(detail_buf, "%s%.4f", _u8L("Warpage Risk: ").c_str(), vertex.warpage_risk);
+                else
+                    sprintf(detail_buf, "%s%s", _u8L("Warpage Risk: ").c_str(), "null");
+                break;
+            case libvgcode::EViewType::WarpageTIGradient:
+                if (is_extrusion && std::isfinite(vertex.warpage_ti_gradient))
+                    sprintf(detail_buf, "%s%.4f", _u8L("TI Gradient: ").c_str(), vertex.warpage_ti_gradient);
+                else
+                    sprintf(detail_buf, "%s%s", _u8L("TI Gradient: ").c_str(), "null");
+                break;
+            case libvgcode::EViewType::WarpageThermalStrain:
+                if (is_extrusion && std::isfinite(vertex.warpage_thermal_strain))
+                    sprintf(detail_buf, "%s%.4f", _u8L("Thermal Strain: ").c_str(), vertex.warpage_thermal_strain);
+                else
+                    sprintf(detail_buf, "%s%s", _u8L("Thermal Strain: ").c_str(), "null");
+                break;
+            case libvgcode::EViewType::WarpageHullShrinkage:
+                if (is_extrusion && std::isfinite(vertex.warpage_hull_shrinkage))
+                    sprintf(detail_buf, "%s%.4f", _u8L("Hull Shrinkage: ").c_str(), vertex.warpage_hull_shrinkage);
+                else
+                    sprintf(detail_buf, "%s%s", _u8L("Hull Shrinkage: ").c_str(), "null");
+                break;
+            case libvgcode::EViewType::WarpageLayerShrinkage:
+                if (is_extrusion && std::isfinite(vertex.warpage_layer_shrinkage))
+                    sprintf(detail_buf, "%s%.4f", _u8L("Layer Shrinkage: ").c_str(), vertex.warpage_layer_shrinkage);
+                else
+                    sprintf(detail_buf, "%s%s", _u8L("Layer Shrinkage: ").c_str(), "null");
                 break;
             default:
                 detail_buf[0] = '\0';
@@ -1195,6 +1267,17 @@ void GCodeViewer::update_by_mode(ConfigOptionMode mode)
         view_type_items.push_back(libvgcode::EViewType::ThermalIndexMin);
         view_type_items.push_back(libvgcode::EViewType::ThermalIndexMax);
     }
+    if (m_has_warpage_data) {
+        view_type_items.push_back(libvgcode::EViewType::WarpageDisplacement);
+        view_type_items.push_back(libvgcode::EViewType::WarpageDispX);
+        view_type_items.push_back(libvgcode::EViewType::WarpageDispY);
+        view_type_items.push_back(libvgcode::EViewType::WarpageDispZ);
+        view_type_items.push_back(libvgcode::EViewType::WarpageRisk);
+        view_type_items.push_back(libvgcode::EViewType::WarpageTIGradient);
+        view_type_items.push_back(libvgcode::EViewType::WarpageThermalStrain);
+        view_type_items.push_back(libvgcode::EViewType::WarpageHullShrinkage);
+        view_type_items.push_back(libvgcode::EViewType::WarpageLayerShrinkage);
+    }
     //if (mode == ConfigOptionMode::comDevelop) {
     //    view_type_items.push_back(EViewType::Tool);
     //}
@@ -1377,13 +1460,15 @@ void GCodeViewer::load_as_gcode(const GCodeProcessorResult& gcode_result, const 
 
     // Helio: detect whether this gcode has any thermal index data
     m_has_thermal_index_data = false;
+    m_has_warpage_data = false;
     {
         const size_t vcount = m_viewer.get_vertices_count();
         for (size_t i = 0; i < vcount; ++i) {
-            if (m_viewer.get_vertex_at(i).thermal_index_mean > -100.0f) {
-                m_has_thermal_index_data = true;
+            const auto &vertex = m_viewer.get_vertex_at(i);
+            m_has_thermal_index_data |= vertex.thermal_index_mean > -100.0f;
+            m_has_warpage_data |= std::isfinite(vertex.warpage_displacement);
+            if (m_has_thermal_index_data && m_has_warpage_data)
                 break;
-            }
         }
     }
     update_by_mode(wxGetApp().get_mode());
@@ -1680,13 +1765,15 @@ void GCodeViewer::load_as_preview(libvgcode::GCodeInputData&& data)
 
     // Helio: detect whether this gcode has any thermal index data
     m_has_thermal_index_data = false;
+    m_has_warpage_data = false;
     {
         const size_t vcount = m_viewer.get_vertices_count();
         for (size_t i = 0; i < vcount; ++i) {
-            if (m_viewer.get_vertex_at(i).thermal_index_mean > -100.0f) {
-                m_has_thermal_index_data = true;
+            const auto &vertex = m_viewer.get_vertex_at(i);
+            m_has_thermal_index_data |= vertex.thermal_index_mean > -100.0f;
+            m_has_warpage_data |= std::isfinite(vertex.warpage_displacement);
+            if (m_has_thermal_index_data && m_has_warpage_data)
                 break;
-            }
         }
     }
     update_by_mode(wxGetApp().get_mode());
@@ -3892,7 +3979,34 @@ void GCodeViewer::render_legend(float &legend_height, int canvas_width, int canv
         { imgui.title(_u8L("Thermal Index (min)")); break; }
     case libvgcode::EViewType::ThermalIndexMax:
         { imgui.title(_u8L("Thermal Index (max)")); break; }
+    case libvgcode::EViewType::WarpageDisplacement:
+        { imgui.title(_u8L("Displacement")); break; }
+    case libvgcode::EViewType::WarpageDispX:
+        { imgui.title(_u8L("Displacement X")); break; }
+    case libvgcode::EViewType::WarpageDispY:
+        { imgui.title(_u8L("Displacement Y")); break; }
+    case libvgcode::EViewType::WarpageDispZ:
+        { imgui.title(_u8L("Displacement Z")); break; }
+    case libvgcode::EViewType::WarpageRisk:
+        { imgui.title(_u8L("Warpage Risk")); break; }
+    case libvgcode::EViewType::WarpageTIGradient:
+        { imgui.title(_u8L("TI Gradient")); break; }
+    case libvgcode::EViewType::WarpageThermalStrain:
+        { imgui.title(_u8L("Thermal Strain")); break; }
+    case libvgcode::EViewType::WarpageHullShrinkage:
+        { imgui.title(_u8L("Hull Shrinkage")); break; }
+    case libvgcode::EViewType::WarpageLayerShrinkage:
+        { imgui.title(_u8L("Layer Shrinkage")); break; }
 
+    case libvgcode::EViewType::WarpageDisplacement: { append_range(m_viewer.get_color_range(libvgcode::EViewType::WarpageDisplacement), 3); break; }
+    case libvgcode::EViewType::WarpageDispX: { append_range(m_viewer.get_color_range(libvgcode::EViewType::WarpageDispX), 3); break; }
+    case libvgcode::EViewType::WarpageDispY: { append_range(m_viewer.get_color_range(libvgcode::EViewType::WarpageDispY), 3); break; }
+    case libvgcode::EViewType::WarpageDispZ: { append_range(m_viewer.get_color_range(libvgcode::EViewType::WarpageDispZ), 3); break; }
+    case libvgcode::EViewType::WarpageRisk: { append_range(m_viewer.get_color_range(libvgcode::EViewType::WarpageRisk), 3); break; }
+    case libvgcode::EViewType::WarpageTIGradient: { append_range(m_viewer.get_color_range(libvgcode::EViewType::WarpageTIGradient), 3); break; }
+    case libvgcode::EViewType::WarpageThermalStrain: { append_range(m_viewer.get_color_range(libvgcode::EViewType::WarpageThermalStrain), 4); break; }
+    case libvgcode::EViewType::WarpageHullShrinkage: { append_range(m_viewer.get_color_range(libvgcode::EViewType::WarpageHullShrinkage), 4); break; }
+    case libvgcode::EViewType::WarpageLayerShrinkage: { append_range(m_viewer.get_color_range(libvgcode::EViewType::WarpageLayerShrinkage), 4); break; }
     case libvgcode::EViewType::Tool:
     {
         // calculate used filaments data

--- a/src/slic3r/GUI/GCodeViewer.hpp
+++ b/src/slic3r/GUI/GCodeViewer.hpp
@@ -253,6 +253,7 @@ mutable bool m_no_render_path { false };
     libvgcode::Viewer m_viewer;
     bool m_loaded_as_preview{ false };
     bool m_has_thermal_index_data{ false };
+    bool m_has_warpage_data{ false };
 
 public:
     GCodeViewer();

--- a/src/slic3r/GUI/LibVGCode/LibVGCodeWrapper.cpp
+++ b/src/slic3r/GUI/LibVGCode/LibVGCodeWrapper.cpp
@@ -228,7 +228,10 @@ GCodeInputData convert(const Slic3r::GCodeProcessorResult& result, const std::ve
                     /* ORCA: Add Pressure Advance visualization support */ 0.0f, curr.pressure_advance,
                     /* ORCA: Add Acceleration visualization support */ curr.acceleration,
                     /* ORCA: Add Jerk visualization support */ curr.jerk,
-            /* Helio: Thermal index from simulation */ curr.thermal_index_mean, curr.thermal_index_min, curr.thermal_index_max };
+            /* Helio: Thermal index from simulation */ curr.thermal_index_mean, curr.thermal_index_min, curr.thermal_index_max,
+                    curr.warpage_displacement, curr.warpage_disp_x, curr.warpage_disp_y, curr.warpage_disp_z,
+                    curr.warpage_risk, curr.warpage_ti_gradient, curr.warpage_thermal_strain,
+                    curr.warpage_hull_shrinkage, curr.warpage_layer_shrinkage };
 #else
               const libvgcode::PathVertex vertex = { convert(prev.position), curr.height, curr.width, curr.feedrate, prev.actual_feedrate,
                     curr.mm3_per_mm, curr.fan_speed, curr.temperature, convert(curr.extrusion_role), curr_type,
@@ -237,7 +240,10 @@ GCodeInputData convert(const Slic3r::GCodeProcessorResult& result, const std::ve
                     /* ORCA: Add Pressure Advance visualization support */ 0.0f, curr.pressure_advance,
                     /* ORCA: Add Acceleration visualization support */ curr.acceleration,
                     /* ORCA: Add Jerk visualization support */ curr.jerk,
-            /* Helio: Thermal index from simulation */ curr.thermal_index_mean, curr.thermal_index_min, curr.thermal_index_max };
+            /* Helio: Thermal index from simulation */ curr.thermal_index_mean, curr.thermal_index_min, curr.thermal_index_max,
+                    curr.warpage_displacement, curr.warpage_disp_x, curr.warpage_disp_y, curr.warpage_disp_z,
+                    curr.warpage_risk, curr.warpage_ti_gradient, curr.warpage_thermal_strain,
+                    curr.warpage_hull_shrinkage, curr.warpage_layer_shrinkage };
 #endif // VGCODE_ENABLE_COG_AND_TOOL_MARKERS
                 ret.vertices.emplace_back(vertex);
             }
@@ -252,7 +258,10 @@ GCodeInputData convert(const Slic3r::GCodeProcessorResult& result, const std::ve
             /* ORCA: Add Pressure Advance visualization support */ 0.0f, curr.pressure_advance,
             /* ORCA: Add Acceleration visualization support */ curr.acceleration,
             /* ORCA: Add Jerk visualization support */ curr.jerk,
-            /* Helio: Thermal index from simulation */ curr.thermal_index_mean, curr.thermal_index_min, curr.thermal_index_max };
+            /* Helio: Thermal index from simulation */ curr.thermal_index_mean, curr.thermal_index_min, curr.thermal_index_max,
+                    curr.warpage_displacement, curr.warpage_disp_x, curr.warpage_disp_y, curr.warpage_disp_z,
+                    curr.warpage_risk, curr.warpage_ti_gradient, curr.warpage_thermal_strain,
+                    curr.warpage_hull_shrinkage, curr.warpage_layer_shrinkage };
 #else
         const libvgcode::PathVertex vertex = { convert(curr.position), curr.height, curr.width, curr.feedrate, curr.actual_feedrate,
             curr.mm3_per_mm, curr.fan_speed, curr.temperature, convert(curr.extrusion_role), curr_type,
@@ -261,7 +270,10 @@ GCodeInputData convert(const Slic3r::GCodeProcessorResult& result, const std::ve
             /* ORCA: Add Pressure Advance visualization support */ 0.0f, curr.pressure_advance,
             /* ORCA: Add Acceleration visualization support */ curr.acceleration,
             /* ORCA: Add Jerk visualization support */ curr.jerk,
-            /* Helio: Thermal index from simulation */ curr.thermal_index_mean, curr.thermal_index_min, curr.thermal_index_max };
+            /* Helio: Thermal index from simulation */ curr.thermal_index_mean, curr.thermal_index_min, curr.thermal_index_max,
+                    curr.warpage_displacement, curr.warpage_disp_x, curr.warpage_disp_y, curr.warpage_disp_z,
+                    curr.warpage_risk, curr.warpage_ti_gradient, curr.warpage_thermal_strain,
+                    curr.warpage_hull_shrinkage, curr.warpage_layer_shrinkage };
 #endif // VGCODE_ENABLE_COG_AND_TOOL_MARKERS
         ret.vertices.emplace_back(vertex);
     }


### PR DESCRIPTION
## Summary
- parse all nine Helio warpage values from enhanced G-code move comments
- carry warpage values through the G-code processor and libvgcode conversion layer
- expose data-dependent warpage color schemes, palettes, legends, and move details in Preview

## Testing
- `git diff --check`
- `g++ -std=c++17 -Isrc/libvgcode/include -Isrc/libvgcode/src -fsyntax-only /tmp/check.cpp`
- `cmake -S src/libvgcode -B /tmp/orca-libvgcode-build -DCMAKE_BUILD_TYPE=Release && cmake --build /tmp/orca-libvgcode-build -j2` *(cannot complete in the standalone configuration because the repository-provided glad headers are not available without the main dependency build)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added warpage visualization in the G-code viewer, including displacement, directional displacement, risk, thermal gradient, thermal strain, hull shrinkage, and layer shrinkage.
  - Warpage view modes now appear automatically when the loaded G-code contains supported warpage data.
  - Added color legends, palettes, ranges, and per-position warpage details for easier analysis.
  - Missing or unavailable warpage values are clearly shown as null.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->